### PR TITLE
Add private prisons to the allowlist

### DIFF
--- a/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
+++ b/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
@@ -59,6 +59,7 @@ generic-service:
   allowlist:
     groups:
       - prisons
+      - private_prisons
       - moj_cloud_platform
       - digital_staff_and_mojo
 


### PR DESCRIPTION
HMP Thameside are a private prison who cannot access this service.

Thameside IP address is covered by `serco` which is on the private prisons list