### PR TITLE
BAVL-693: Revert to only showing videoUrl for VLB_COURT_MAIN appointments

### DIFF
--- a/server/services/scheduleService.test.ts
+++ b/server/services/scheduleService.test.ts
@@ -480,7 +480,6 @@ describe('Schedule service', () => {
               tags: [],
               videoBookingId: 2,
               videoLinkRequired: false,
-              videoLink: 'http://video.url',
               viewAppointmentLink: 'http://localhost:3000/appointment-details/5',
             },
           ],
@@ -519,7 +518,7 @@ describe('Schedule service', () => {
               endTime: '20:00',
               externalAgencyCode: 'ABERCV',
               externalAgencyDescription: 'Aberystwyth Civil',
-              lastUpdatedOrCreated: '2025-03-10T00:00:00.000Z',
+              lastUpdatedOrCreated: startOfToday().toISOString(),
               prisoner: {
                 cellLocation: 'A-001',
                 firstName: 'Joe',
@@ -783,7 +782,7 @@ describe('Schedule service', () => {
               endTime: '20:00',
               externalAgencyCode: 'ABERCV',
               externalAgencyDescription: 'Aberystwyth Civil',
-              lastUpdatedOrCreated: '2025-03-10T00:00:00.000Z',
+              lastUpdatedOrCreated: startOfToday().toISOString(),
               prisoner: {
                 cellLocation: 'A-001',
                 firstName: 'Joe',
@@ -914,7 +913,7 @@ describe('Schedule service', () => {
               endTime: '20:00',
               externalAgencyCode: 'ABERCV',
               externalAgencyDescription: 'Aberystwyth Civil',
-              lastUpdatedOrCreated: '2025-03-10T00:00:00.000Z',
+              lastUpdatedOrCreated: startOfToday().toISOString(),
               prisoner: {
                 cellLocation: 'A-001',
                 firstName: 'Joe',
@@ -1053,7 +1052,6 @@ describe('Schedule service', () => {
               tags: [],
               videoBookingId: 2,
               videoLinkRequired: false,
-              videoLink: 'http://video.url',
               viewAppointmentLink: 'http://localhost:3000/appointment-details/5',
             },
           ],
@@ -1068,7 +1066,7 @@ describe('Schedule service', () => {
               endTime: '20:00',
               externalAgencyCode: 'ABERCV',
               externalAgencyDescription: 'Aberystwyth Civil',
-              lastUpdatedOrCreated: '2025-03-10T00:00:00.000Z',
+              lastUpdatedOrCreated: startOfToday().toISOString(),
               prisoner: {
                 cellLocation: 'A-001',
                 firstName: 'Joe',

--- a/server/services/scheduleService.ts
+++ b/server/services/scheduleService.ts
@@ -139,10 +139,6 @@ export default class ScheduleService {
     const createdTime = bvlsAppointment?.createdTime || scheduledAppointment.createdTime
     const updatedTime = bvlsAppointment?.updatedTime || scheduledAppointment.updatedTime
     const videoLinkRequired = bvlsAppointment?.appointmentType === 'VLB_COURT_MAIN'
-    const isMainAppointmentOfBooking =
-      bvlsAppointment &&
-      bvlsAppointment?.appointmentType !== 'VLB_COURT_PRE' &&
-      bvlsAppointment?.appointmentType !== 'VLB_COURT_POST'
 
     const buildTags = () => {
       const appointmentDate = parseDate(scheduledAppointment.date)
@@ -186,7 +182,7 @@ export default class ScheduleService {
       appointmentLocationDescription: scheduledAppointment.locationDescription,
       videoBookingId: bvlsAppointment?.videoBookingId,
       videoLinkRequired,
-      videoLink: isMainAppointmentOfBooking ? bvlsAppointment.videoUrl : undefined,
+      videoLink: videoLinkRequired ? bvlsAppointment.videoUrl : undefined,
       appointmentSubtypeDescription:
         (bvlsAppointment?.appointmentType === 'VLB_COURT_MAIN' && bvlsAppointment?.hearingTypeDescription) ||
         (bvlsAppointment?.appointmentType === 'VLB_PROBATION' && bvlsAppointment?.probationMeetingTypeDescription) ||


### PR DESCRIPTION
Video url should only be displayed for VLB main appointments. PVL room link should not be shown