### PR TITLE
BAVL-669: Add some custom events for application insights

### DIFF
--- a/server/views/pages/dailySchedule/dailySchedule.njk
+++ b/server/views/pages/dailySchedule/dailySchedule.njk
@@ -162,8 +162,31 @@
                         </div>
                     {% endif %}
                     <div class="hmpps-print-and-export">
-                        <button class="hmpps-print-and-export--export">Export as spreadsheet (.csv file)</button>
-                        <button class="hmpps-print-and-export--print">Print schedule</button>
+                        <button class="hmpps-print-and-export--export"
+                                data-track-click-event="Daily-Schedule-CSV-Export"
+                                data-track-event-properties="{{
+                                    {
+                                        user: user.username,
+                                        prisonCode: user.activeCaseLoadId,
+                                        scheduleDate: date | formatDate('yyyy-MM-dd'),
+                                        exportedDate: now() | formatDate('yyyy-MM-dd'),
+                                        filtersApplied: true if session.journey.scheduleFilters else false
+                                    } | dump
+                                }}"
+                        >Export as spreadsheet (.csv file)</button>
+
+                        <button class="hmpps-print-and-export--print"
+                                data-track-click-event="Daily-Schedule-Print"
+                                data-track-event-properties="{{
+                                    {
+                                        user: user.username,
+                                        prisonCode: user.activeCaseLoadId,
+                                        scheduleDate: date | formatDate('yyyy-MM-dd'),
+                                        printedDate: now() | formatDate('yyyy-MM-dd'),
+                                        filtersApplied: true if session.journey.scheduleFilters else false
+                                    } | dump
+                                }}"
+                        >Print schedule</button>
                     </div>
                 </div>
                 {{ govukTable({

--- a/server/views/partials/showProfileLink.njk
+++ b/server/views/partials/showProfileLink.njk
@@ -7,7 +7,14 @@
             {% if params.inPrison %}
                 <a href="{{ dpsUrl }}/prisoner/{{ params.prisonerNumber }}" rel="noreferrer noopener"
                    target="_blank"
-                   class="govuk-link govuk-link--no-visited-state">
+                   class="govuk-link govuk-link--no-visited-state"
+                   data-track-click-event="Daily-Schedule-View-Prisoner-Profile"
+                   data-track-event-properties="{{
+                       {
+                           hasAlerts: params.hasAlerts
+                       } | dump
+                   }}"
+                >
                     {{ name | safe }}
                     <span class="govuk-visually-hidden">(opens in new tab)</span>
                 </a>


### PR DESCRIPTION
Tracks: 

- Visits to daily schedule per prison and times this is being accessed (By default)
- Number of csv downloads
- Number of prints
- Date the daily schedule is being printed and what date it is being printed for
- Number of times the daily schedule is printed with filters applied
- Number of times there is a click through to the prisoner profile
- Number of times there is a click through to the prisoner profile with an alert present