### PR TITLE
BAVL-669: Remove auto tracking of click events, as it may have recorded PII.

### DIFF
--- a/frontend/application-insights-setup.js
+++ b/frontend/application-insights-setup.js
@@ -1,35 +1,19 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
-import { ClickAnalyticsPlugin } from '@microsoft/applicationinsights-clickanalytics-js'
 
 if (window.applicationInsightsConnectionString) {
-  const clickPluginInstance = new ClickAnalyticsPlugin()
-  const clickPluginConfig = {
-    autoCapture: true,
-    dataTags: {
-      useDefaultContentNameOrId: true,
-    },
-  }
-  const snippet = {
+  const init = new ApplicationInsights({
     config: {
       connectionString: window.applicationInsightsConnectionString,
-      extensions: [
-        clickPluginInstance,
-      ],
-      extensionConfig: {
-        [clickPluginInstance.identifier]: clickPluginConfig,
-      },
       autoTrackPageVisitTime: true,
     },
-  }
-
-  const init = new ApplicationInsights(snippet)
+  })
   const appInsights = init.loadAppInsights()
   appInsights.addTelemetryInitializer(function (envelope) {
-    envelope.tags["ai.cloud.role"] = window.applicationInsightsApplicationName
-    envelope.tags["ai.application.ver"] = window.buildNumber
-  });
+    envelope.tags['ai.cloud.role'] = window.applicationInsightsApplicationName
+    envelope.tags['ai.application.ver'] = window.buildNumber
+  })
   appInsights.setAuthenticatedUserContext(window.authenticatedUser)
-  appInsights.trackPageView();
+  appInsights.trackPageView()
 
   initMetricClickEvents(appInsights)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.741.0",
-        "@microsoft/applicationinsights-clickanalytics-js": "^3.1.0",
         "@microsoft/applicationinsights-web": "^3.1.0",
         "@ministryofjustice/frontend": "^3.3.1",
         "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",
@@ -1981,22 +1980,6 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-clickanalytics-js": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-clickanalytics-js/-/applicationinsights-clickanalytics-js-3.3.6.tgz",
-      "integrity": "sha512-gsnTa8KnddfosZ00tclw/AqwfvaaLIJtFcRrNcYDJjrMTWHIuhEWiA8kv0uU5Vt3Dir/N5u9FY+H1Gtb01OxJw==",
-      "dependencies": {
-        "@microsoft/applicationinsights-common": "3.3.6",
-        "@microsoft/applicationinsights-core-js": "3.3.6",
-        "@microsoft/applicationinsights-properties-js": "3.3.6",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.741.0",
-    "@microsoft/applicationinsights-clickanalytics-js": "^3.1.0",
     "@microsoft/applicationinsights-web": "^3.1.0",
     "@ministryofjustice/frontend": "^3.3.1",
     "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",


### PR DESCRIPTION
The click events we are interested in are being tracked by custom events. An example of an event which contained PII is clicking the prisoner profile. This had the EventName as the prisoner's name, and since the event name for these will be different every time, they cannot be grouped in a query anyway. Clicking the prisoner profile is instead tracked by an event called `Daily-Schedule-View-Prisoner-Profile`

<img width="517" alt="Screenshot 2025-04-07 at 14 17 21" src="https://github.com/user-attachments/assets/ab044b0f-1e47-4439-ad37-16b6094776b2" />

