### PR TITLE
BAVL-851 resolving CVE 401 transient dependendency and CVE 338 3rd party dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "passport-oauth2": "^1.8.0",
         "redis": "^4.7.0",
         "reflect-metadata": "^0.2.2",
-        "superagent": "^10.1.1",
+        "superagent": "^10.2.1",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -2157,6 +2157,18 @@
       "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.8.tgz",
       "integrity": "sha512-62Y1mHgSu99IK4BRKC3sxdj/uIBHy6SDof3WUd29jom2HQy8sGCUdbYtFwMOkbUS6rahkL11Eg/ImtwsQsCnyw=="
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2283,6 +2295,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -7077,12 +7098,17 @@
       }
     },
     "node_modules/formidable": {
-      "version": "3.5.2",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -8143,13 +8169,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -12978,7 +12997,9 @@
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/superagent": {
-      "version": "10.1.1",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
+      "integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
       "license": "MIT",
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -12986,7 +13007,7 @@
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^3.5.2",
+        "formidable": "^3.5.4",
         "methods": "^1.1.2",
         "mime": "2.6.0",
         "qs": "^6.11.0"
@@ -13661,10 +13682,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "passport-oauth2": "^1.8.0",
     "redis": "^4.7.0",
     "reflect-metadata": "^0.2.2",
-    "superagent": "^10.1.1",
+    "superagent": "^10.2.1",
     "uuid": "^11.0.5"
   },
   "devDependencies": {
@@ -179,7 +179,7 @@
     "wiremock": "^3.11.0"
   },
   "overrides": {
-    "undici": "^6.21.1",
+    "undici": "^6.21.3",
     "@babel/helpers": "^7.26.10"
   }
 }


### PR DESCRIPTION
CVE's described below:

```
CVE-401
name: undici
severity: low
isDirect: False
via: [{'source': 1104500, 'name': 'undici', 'dependency': 'undici', 'title': 'undici Denial of Service attack via bad certificate data', 'url': 'https://github.com/advisories/GHSA-cxrh-j4jr-qwg3', 'severity': 'low', 'cwe': ['CWE-401'], 'cvss': {'score': 3.1, 'vectorString': 'CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L'}, 'range': '>=6.0.0 <6.21.2'}]
effects: []
range: 6.0.0 - 6.21.1
nodes: ['node_modules/undici']
fixAvailable: True 
```

```
CVE 338
name: formidable
severity: low
isDirect: False
via: [{'source': 1104171, 'name': 'formidable', 'dependency': 'formidable', 'title': 'Formidable relies on hexoid to prevent guessing of filenames for untrusted executable content', 'url': 'https://github.com/advisories/GHSA-75v8-2h7p-7m2m', 'severity': 'low', 'cwe': ['CWE-338'], 'cvss': {'score': 3.1, 'vectorString': 'CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N'}, 'range': '>=3.1.1-canary.20211030 <3.5.3'}]
effects: []
range: 3.1.1-canary.20211030 - 3.5.2
nodes: ['node_modules/formidable']
fixAvailable: True 
```
