### PR TITLE
BAVL-876 make CVP link into clickable hyperlink.

### DIFF
--- a/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
+++ b/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
@@ -55,6 +55,8 @@ generic-service:
     sqs-hmpps-audit-secret:
       AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
       AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
+    feature-toggles:
+      FEATURE_HMCTS_LINK_GUEST_PIN: "FEATURE_HMCTS_LINK_GUEST_PIN"
 
   allowlist:
     groups:

--- a/server/config.ts
+++ b/server/config.ts
@@ -183,4 +183,7 @@ export default {
   environmentName: get('ENVIRONMENT_NAME', ''),
   feedbackUrl: get('FEEDBACK_URL', '#'),
   applicationInsightsConnectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', '', requiredInProduction),
+  featureToggles: {
+    hmctsLinkAndGuestPin: get('FEATURE_HMCTS_LINK_GUEST_PIN', 'false') === 'true',
+  },
 }

--- a/server/services/scheduleService.test.ts
+++ b/server/services/scheduleService.test.ts
@@ -1550,6 +1550,134 @@ describe('Schedule service', () => {
 
         expect(result.appointmentGroups.pop().pop()).toMatchObject({ tags: ['PIN_PROTECTED'] })
       })
+
+      it('should add the LINK_MISSING tag for appointments without video link or HMCTS number', async () => {
+        appointments = [
+          {
+            id: 1,
+            date: formatDate(startOfToday(), 'yyyy-MM-dd'),
+            offenderNo: 'ABC123',
+            startTime: '08:00',
+            endTime: '09:00',
+            locationId: 1,
+            locationDescription: 'ROOM 1',
+            appointmentTypeDescription: 'Video Link - Court Hearing',
+            status: 'ACTIVE',
+            viewAppointmentLink: 'http://localhost:3000/appointment-details/1',
+            createdTime: startOfYesterday().toISOString(),
+          },
+        ]
+
+        bvlsAppointments = [
+          {
+            videoBookingId: 1,
+            statusCode: 'ACTIVE',
+            prisonerNumber: 'ABC123',
+            startTime: '08:00',
+            endTime: '09:00',
+            prisonLocKey: 'ROOM_1',
+            dpsLocationId: 'abc-123',
+            appointmentType: 'VLB_COURT_MAIN',
+            courtCode: 'ABERCV',
+            courtDescription: 'Aberystwyth Civil',
+            hearingTypeDescription: 'Appeal',
+          },
+        ] as BvlsAppointment[]
+
+        appointmentService.getVideoLinkAppointments.mockResolvedValue(appointments)
+        bookAVideoLinkApiClient.getVideoLinkAppointments.mockResolvedValue(bvlsAppointments)
+
+        const date = new Date()
+        const result = await scheduleService.getSchedule('MDI', date, undefined, 'ACTIVE', user)
+
+        expect(result.appointmentGroups.pop().pop()).toMatchObject({ tags: ['LINK_MISSING'] })
+      })
+
+      it('should not add the LINK_MISSING tag for appointments with a video link', async () => {
+        appointments = [
+          {
+            id: 1,
+            date: formatDate(startOfToday(), 'yyyy-MM-dd'),
+            offenderNo: 'ABC123',
+            startTime: '08:00',
+            endTime: '09:00',
+            locationId: 1,
+            locationDescription: 'ROOM 1',
+            appointmentTypeDescription: 'Video Link - Court Hearing',
+            status: 'ACTIVE',
+            viewAppointmentLink: 'http://localhost:3000/appointment-details/1',
+            createdTime: startOfYesterday().toISOString(),
+          },
+        ]
+
+        bvlsAppointments = [
+          {
+            videoBookingId: 1,
+            statusCode: 'ACTIVE',
+            prisonerNumber: 'ABC123',
+            startTime: '08:00',
+            endTime: '09:00',
+            prisonLocKey: 'ROOM_1',
+            dpsLocationId: 'abc-123',
+            appointmentType: 'VLB_COURT_MAIN',
+            courtCode: 'ABERCV',
+            courtDescription: 'Aberystwyth Civil',
+            hearingTypeDescription: 'Appeal',
+            videoUrl: 'http://video.url',
+          },
+        ] as BvlsAppointment[]
+
+        appointmentService.getVideoLinkAppointments.mockResolvedValue(appointments)
+        bookAVideoLinkApiClient.getVideoLinkAppointments.mockResolvedValue(bvlsAppointments)
+
+        const date = new Date()
+        const result = await scheduleService.getSchedule('MDI', date, undefined, 'ACTIVE', user)
+
+        expect(result.appointmentGroups.pop().pop()).toMatchObject({ tags: [] })
+      })
+
+      it('should not add the LINK_MISSING tag for appointments with a HMCTS number', async () => {
+        appointments = [
+          {
+            id: 1,
+            date: formatDate(startOfToday(), 'yyyy-MM-dd'),
+            offenderNo: 'ABC123',
+            startTime: '08:00',
+            endTime: '09:00',
+            locationId: 1,
+            locationDescription: 'ROOM 1',
+            appointmentTypeDescription: 'Video Link - Court Hearing',
+            status: 'ACTIVE',
+            viewAppointmentLink: 'http://localhost:3000/appointment-details/1',
+            createdTime: startOfYesterday().toISOString(),
+          },
+        ]
+
+        bvlsAppointments = [
+          {
+            videoBookingId: 1,
+            statusCode: 'ACTIVE',
+            prisonerNumber: 'ABC123',
+            startTime: '08:00',
+            endTime: '09:00',
+            prisonLocKey: 'ROOM_1',
+            dpsLocationId: 'abc-123',
+            appointmentType: 'VLB_COURT_MAIN',
+            courtCode: 'ABERCV',
+            courtDescription: 'Aberystwyth Civil',
+            hearingTypeDescription: 'Appeal',
+            hmctsNumber: '12345678',
+          },
+        ] as BvlsAppointment[]
+
+        appointmentService.getVideoLinkAppointments.mockResolvedValue(appointments)
+        bookAVideoLinkApiClient.getVideoLinkAppointments.mockResolvedValue(bvlsAppointments)
+
+        const date = new Date()
+        const result = await scheduleService.getSchedule('MDI', date, undefined, 'ACTIVE', user)
+
+        expect(result.appointmentGroups.pop().pop()).toMatchObject({ tags: [] })
+      })
     })
   })
 })

--- a/server/services/scheduleService.ts
+++ b/server/services/scheduleService.ts
@@ -31,7 +31,7 @@ const RELEVANT_ALERTS = {
   RISK_TO_FEMALES: 'XRF',
 }
 
-type ScheduleItem = {
+export type ScheduleItem = {
   appointmentId: number
   prisoner: {
     prisonerNumber: string
@@ -59,6 +59,7 @@ type ScheduleItem = {
   cancelledTime?: string
   cancelledBy?: string
   lastUpdatedOrCreated: string
+  hmctsNumber?: string
 }
 
 export type DailySchedule = {
@@ -207,6 +208,7 @@ export default class ScheduleService {
       cancelledTime: scheduledAppointment.cancelledTime,
       cancelledBy: await this.getCancelledBy(scheduledAppointment, bvlsAppointment, user),
       lastUpdatedOrCreated: updatedTime || createdTime,
+      hmctsNumber: videoLinkRequired ? bvlsAppointment.hmctsNumber : undefined,
     }
   }
 

--- a/server/services/scheduleService.ts
+++ b/server/services/scheduleService.ts
@@ -176,7 +176,7 @@ export default class ScheduleService {
       return [
         isNew ? 'NEW' : undefined,
         isUpdated ? 'UPDATED' : undefined,
-        videoLinkRequired && !bvlsAppointment?.videoUrl ? 'LINK_MISSING' : undefined,
+        videoLinkRequired && !bvlsAppointment?.videoUrl && !bvlsAppointment?.hmctsNumber ? 'LINK_MISSING' : undefined,
         isPinProtected ? 'PIN_PROTECTED' : undefined,
       ].filter(Boolean)
     }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -63,4 +63,5 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addGlobal('now', () => new Date())
   njkEnv.addGlobal('dpsUrl', config.dpsUrl)
   njkEnv.addGlobal('activitiesAndAppointmentsUrl', config.activitiesAndAppointmentsUrl)
+  njkEnv.addGlobal('hmctsLinkAndGuestPinEnabled', config.featureToggles.hmctsLinkAndGuestPin)
 }

--- a/server/views/pages/dailySchedule/dailySchedule.njk
+++ b/server/views/pages/dailySchedule/dailySchedule.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "partials/showProfileLink.njk" import showProfileLink %}
+{% from "partials/showProfileLink.njk" import showProfileLink %}
+{% from "partials/toCourtLink.njk" import toCourtLink %}
 {% from "partials/stat.njk" import stat %}
 
 {% set isToday = (date | formatDate('yyyy-MM-dd')) == (now() | formatDate('yyyy-MM-dd'))  %}
@@ -134,8 +136,12 @@
                             classes: classes
                         },
                         {
-                            html: scheduleItem.videoLink or ('None entered' if scheduleItem.videoLinkRequired) or (('--' if appointmentGroup.length == 1) + '<span class="govuk-visually-hidden">Not required</span>'),
-                            classes: classes
+                            html: (toCourtLink(scheduleItem, hmctsLinkAndGuestPinEnabled) if scheduleItem.videoLinkRequired) or (('--' if appointmentGroup.length == 1) + '<span class="govuk-visually-hidden">Not required</span>'),
+                            classes: classes,
+                            attributes: {
+                              'width': '14%',
+                              'word-break': 'break-all'
+                            }
                         },
                         {
                             html: bookingStatuses(scheduleItem.tags) if (appointmentGroup.length == 1 or loop.index == 2),

--- a/server/views/partials/toCourtLink.njk
+++ b/server/views/partials/toCourtLink.njk
@@ -1,0 +1,17 @@
+{# Macro to format the CVP link based on known information and the feature switch value #}
+
+{% macro toCourtLink(item, feature) %}
+    {% if feature and item.hmctsNumber %}
+      <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word" href="https://HMCTS{{ item.hmctsNumber }}@meet.video.justice.gov.uk" rel="noreferrer noopener" target="_blank">
+        {{ item.hmctsNumber }}
+      </a>
+    {% elseif feature and item.videoLink %}
+      <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word" href="{{ item.videoLink }}" rel="noreferrer noopener" target="_blank">
+        {{ item.videoLink.substring(0,15) }}
+      </a>
+    {% elseif item.videoLink %}
+      {{ item.videoLink }}
+    {% else %}
+      None entered
+    {% endif %}
+{% endmacro %}

--- a/server/views/partials/toCourtLink.njk
+++ b/server/views/partials/toCourtLink.njk
@@ -3,7 +3,7 @@
 {% macro toCourtLink(item, feature) %}
     {% if feature and item.hmctsNumber %}
       <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word" href="https://HMCTS{{ item.hmctsNumber }}@meet.video.justice.gov.uk" rel="noreferrer noopener" target="_blank">
-        {{ item.hmctsNumber }}
+        HMCTS{{ item.hmctsNumber }}
       </a>
     {% elseif feature and item.videoLink %}
       <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word" href="{{ item.videoLink }}" rel="noreferrer noopener" target="_blank">


### PR DESCRIPTION
This feature toggled change makes the CVP link navigate to the link in a new tab.

I suspect given the ongoing conversations this will likely change.

The copy to clipboard part of the is still to be done.

![cvp-link](https://github.com/user-attachments/assets/c57f7114-dafb-49f0-aba6-dfed3fd1634c)


