### PR TITLE
BAVL-979 show empty CSV column instead of undefined for last updated column for whereabouts prisons non-bvls appointments e.g legal.

### DIFF
--- a/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.test.ts
@@ -28,14 +28,16 @@ const expectedCsvNoPickupTimes =
   '\nJohn Smith,ABC123,A-1-001,10:45,11:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00' +
   '\nJohn Smith,ABC123,A-1-001,11:00,12:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00' +
   '\nJohn Doe,DEF123,B-1-001,11:00,12:00,Court Hearing,,B Wing Video Link,,HMCTS 54321,10 December 2024 at 00:00' +
-  '\nJane Doe,HIJ123,C-1-001,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00'
+  '\nJane Doe,HIJ123,C-1-001,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00' +
+  '\nFred Flintrock,BC5000,B-1-5000,16:00,17:00,Court Hearing,,Z Wing Video Link,,,'
 
 const expectedCsvWithPickupTimes =
   'Prisoner name,Prison number,Cell number,Pick-up time,Appointment start time,Appointment end time,Appointment type,Appointment subtype,Room location,Court or probation team,Video link,Last updated' +
   '\nJohn Smith,ABC123,A-1-001,10:15,10:45,11:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00' +
   '\nJohn Smith,ABC123,A-1-001,,11:00,12:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00' +
   '\nJohn Doe,DEF123,B-1-001,10:30,11:00,12:00,Court Hearing,,B Wing Video Link,,HMCTS 54321,10 December 2024 at 00:00' +
-  '\nJane Doe,HIJ123,C-1-001,10:30,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00'
+  '\nJane Doe,HIJ123,C-1-001,10:30,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00' +
+  '\nFred Flintrock,BC5000,B-1-5000,15:30,16:00,17:00,Court Hearing,,Z Wing Video Link,,,'
 
 beforeEach(() => {
   scheduleService.getSchedule.mockResolvedValue({
@@ -84,6 +86,17 @@ beforeEach(() => {
           appointmentTypeDescription: 'Court Hearing',
           appointmentLocationDescription: 'C Wing Video Link',
           lastUpdatedOrCreated: '2024-12-10T00:00:00Z',
+          videoLinkRequired: true,
+        },
+      ],
+      [
+        {
+          prisoner: { firstName: 'Fred', lastName: 'Flintrock', prisonerNumber: 'BC5000', cellLocation: 'B-1-5000' },
+          startTime: '16:00',
+          endTime: '17:00',
+          appointmentTypeDescription: 'Court Hearing',
+          appointmentLocationDescription: 'Z Wing Video Link',
+          lastUpdatedOrCreated: undefined,
           videoLinkRequired: true,
         },
       ],

--- a/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.ts
+++ b/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.ts
@@ -52,7 +52,9 @@ export default class DownloadCsvHandler implements PageHandler {
         'Room location': item.appointmentLocationDescription,
         'Court or probation team': item.externalAgencyDescription || '',
         'Video link': this.courtLinkFor(item) || '',
-        'Last updated': formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm"),
+        'Last updated': item.lastUpdatedOrCreated
+          ? formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm")
+          : '',
       })),
     )
   }
@@ -71,7 +73,9 @@ export default class DownloadCsvHandler implements PageHandler {
         'Room location': item.appointmentLocationDescription,
         'Court or probation team': item.externalAgencyDescription || '',
         'Video link': this.courtLinkFor(item) || '',
-        'Last updated': formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm"),
+        'Last updated': item.lastUpdatedOrCreated
+          ? formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm")
+          : '',
       })),
     )
   }


### PR DESCRIPTION
Changes to fix this:

![image](https://github.com/user-attachments/assets/a9ac693f-10d5-475a-833e-e23dd47856b2)
