### PR TITLE
BAVL-983: Displaying valid/invalid, long/short links on the Daily Schedule

### DIFF
--- a/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
@@ -360,7 +360,7 @@ describe('GET - with pick-up time enabled', () => {
         })
 
         const pickUps = getByClass($, 'show-hide-details')
-        expect(pickUps.text()).toContain('Show pick-up time')
+        expect(pickUps.text()).toContain('Pick-up time')
         expect(scheduleService.getSchedule).toHaveBeenLastCalledWith('MDI', startOfDay(date), filters, 'ACTIVE', user)
       })
   })

--- a/server/views/partials/showStartAndEndTime.njk
+++ b/server/views/partials/showStartAndEndTime.njk
@@ -14,7 +14,7 @@
         {% if pickUpTime %}
             <div class="govuk-body-s govuk-!-font-size-14 govuk-!-margin-top-2 govuk-link--no-visited-state">
                 {{ govukDetails({
-                    summaryText: "Show pick-up time",
+                    summaryText: "Pick-up time",
                     text: pickUpTime,
                     open: false,
                     classes: "govuk-body-s govuk-!-font-size-14 show-hide-details"

--- a/server/views/partials/toCourtLink.njk
+++ b/server/views/partials/toCourtLink.njk
@@ -4,27 +4,34 @@
 
 {% macro toCourtLink(item, feature) %}
     {% if feature and item.hmctsNumber %}
+      {# If the HMCTS number is present construct a full, clickable link to join the meeting #}
       <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word"
          href="{{ (item.hmctsNumber | toFullCourtLink) }}"
          rel="noreferrer noopener" target="_blank">
         HMCTS{{ item.hmctsNumber }}
       </a>
     {% elseif feature and item.videoLink and (item.videoLink | isValidUrl) %}
+      {# If valid URL is present construct a clickable link to this URL with the link text "Court link" #}
       <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word"
          href="{{ item.videoLink }}"
          rel="noreferrer noopener" target="_blank">
         Court link
       </a>
-    {% elseif feature and item.videoLink and not (item.videoLink | isValidUrl) %}
-        <div class="govuk-body-s govuk-!-margin-top-2 govuk-link--no-visited-state">
-            {{ govukDetails({
-                summaryText: "Check booking",
-                text: "Select view or edit to check court link entered",
-                open: false,
-                classes: "govuk-body-s"
-            }) }}
+    {% elseif feature and item.videoLink and not (item.videoLink | isValidUrl) and item.videoLink.length <= 35 %}
+        {# If videoLink is present but is not a valid URL but is under 35 chars show the value in plain text #}
+        <div class="govuk-body-s">
+            {{ item.videoLink }}
         </div>
+    {% elseif feature and item.videoLink and not (item.videoLink | isValidUrl) and item.videoLink.length > 35 %}
+        {# If the link is present but not a valid URL and is over 35 chars show a details component #}
+        {{ govukDetails({
+           summaryText: "Check booking",
+           text: "Select view or edit to check court link entered",
+           open: false,
+           classes: "govuk-body-s"
+        }) }}
     {% elseif item.videoLink %}
+      {# Default if present and feature is off #}
       {{ item.videoLink }}
     {% else %}
       None entered


### PR DESCRIPTION
Also shortens the `Show pick-up time` details to `Pick-up time`.

After:
<img width="669" height="867" alt="image" src="https://github.com/user-attachments/assets/f5a63b6a-5f1a-4430-8b62-f4c82a2557e9" />
