### PR TITLE
BAVL-995 adding MoJ git leaks component to the project to assist with preventing accidental leaking of secrets.

### DIFF
--- a/.gitleaks/.gitleaksignore
+++ b/.gitleaks/.gitleaksignore
@@ -1,0 +1,1 @@
+# The Fingerprint of false positive alerts can be added here to be excluded from future scans.

--- a/.gitleaks/config.toml
+++ b/.gitleaks/config.toml
@@ -1,0 +1,3 @@
+title = "HMPPS Gitleaks configuration"
+[extend]
+path = "./node_modules/@ministryofjustice/hmpps-precommit-hooks/config.toml"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,5 @@
-NODE_ENV=dev && node_modules/.bin/lint-staged && npm run typecheck && npm run lint:fix && npm test
+#!/bin/bash
+NODE_ENV=dev \
+npm run precommit:secrets \
+&& npm run precommit:lint \
+&& npm run precommit:verify

--- a/demo-password.txt
+++ b/demo-password.txt
@@ -1,0 +1,1 @@
+fake_aws_key=AKIA7635372522960ASD

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       },
       "devDependencies": {
         "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
+        "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
         "@rollup/plugin-commonjs": "^28.0.2",
         "@rollup/plugin-node-resolve": "^15.3.1",
         "@tsconfig/node22": "^22.0.0",
@@ -81,7 +82,6 @@
         "grunt-contrib-uglify": "^5.2.2",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-rollup": "^12.0.0",
-        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-html-reporter": "^3.10.2",
         "jest-junit": "^16.0.0",
@@ -2142,6 +2142,24 @@
       "peerDependencies": {
         "agentkeepalive": "4.x",
         "superagent": "^10.x"
+      }
+    },
+    "node_modules/@ministryofjustice/hmpps-precommit-hooks": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-precommit-hooks/-/hmpps-precommit-hooks-0.0.3.tgz",
+      "integrity": "sha512-oZkqpUXqG4gA0mbp8u+1Uy9AtTxFM8dRTWoyLpHAgU+3NqVASOZiRG2LmMQ2p+wScmCZtXDmPIgcMNX5QR4www==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "husky": "^9.1.7"
+      },
+      "bin": {
+        "hmpps-precommit-hooks": "bin/init.sh",
+        "hmpps-precommit-hooks-prepare": "bin/prepare.sh",
+        "test-secret-protection": "bin/test.sh"
+      },
+      "engines": {
+        "node": "20 || 22"
       }
     },
     "node_modules/@nevware21/ts-async": {
@@ -8286,6 +8304,8 @@
     },
     "node_modules/husky": {
       "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:ministryofjustice/hmpps-video-conference-schedule-ui.git",
   "license": "MIT",
   "scripts": {
-    "prepare": "husky",
+    "prepare": "hmpps-precommit-hooks-prepare",
     "compile-assets": "grunt",
     "watch-node": "nodemon --ignore '*.test.ts' -r dotenv/config ./server.ts",
     "watch-assets": "npm run build:dev && grunt watch",
@@ -22,7 +22,10 @@
     "security_audit": "better-npm-audit audit",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",
-    "clean": "rm -rf dist assets build node_modules stylesheets"
+    "clean": "rm -rf dist assets build node_modules stylesheets",
+    "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml",
+    "precommit:lint": "node_modules/.bin/lint-staged",
+    "precommit:verify": "npm run typecheck && npm test"
   },
   "engines": {
     "node": "^22",
@@ -123,6 +126,7 @@
   },
   "devDependencies": {
     "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
+    "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^15.3.1",
     "@tsconfig/node22": "^22.0.0",
@@ -160,7 +164,6 @@
     "grunt-contrib-uglify": "^5.2.2",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-rollup": "^12.0.0",
-    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-html-reporter": "^3.10.2",
     "jest-junit": "^16.0.0",


### PR DESCRIPTION
Adds a precommit gitleaks check to the project to assist with preventing accidental committing secrets to the codebase.