### PR TITLE
BAVL-906 small css tweak to add a single left line border to the bulk print option.

### DIFF
--- a/frontend/components/movement-slip/_movement-slip.scss
+++ b/frontend/components/movement-slip/_movement-slip.scss
@@ -6,7 +6,10 @@
   font-size: 1.1875rem;
   text-decoration-thickness: unset;
   text-underline-offset: unset;
-  margin-left: 15px;
+  border-left-style: solid;
+  border-left-width: 1px;
+  border-left-color: $govuk-border-colour;
+  padding-left: 8px;
 
   a {
     @extend .govuk-link;


### PR DESCRIPTION
<img width="1820" height="322" alt="image" src="https://github.com/user-attachments/assets/264805ee-0131-4987-9b5e-2c2b3885b4f4" />
