### PR TITLE
BAVL-1077 removal of feature guest PIN/link toggle, code no longer needs to be behind the toggle.

### DIFF
--- a/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
+++ b/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
@@ -56,8 +56,6 @@ generic-service:
     sqs-hmpps-audit-secret:
       AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
       AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
-    feature-toggles:
-      FEATURE_HMCTS_LINK_GUEST_PIN: "FEATURE_HMCTS_LINK_GUEST_PIN"
 
   allowlist:
     groups:

--- a/server/config.ts
+++ b/server/config.ts
@@ -184,7 +184,4 @@ export default {
   feedbackUrl: get('FEEDBACK_URL', '#'),
   applicationInsightsConnectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', '', requiredInProduction),
   featureBulkPrintMovementSlips: get('FEATURE_BULK_PRINT_MOVEMENT_SLIPS', 'false') === 'true',
-  featureToggles: {
-    hmctsLinkAndGuestPin: get('FEATURE_HMCTS_LINK_GUEST_PIN', 'false') === 'true',
-  },
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -77,6 +77,5 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addGlobal('now', () => new Date())
   njkEnv.addGlobal('dpsUrl', config.dpsUrl)
   njkEnv.addGlobal('activitiesAndAppointmentsUrl', config.activitiesAndAppointmentsUrl)
-  njkEnv.addGlobal('hmctsLinkAndGuestPinEnabled', config.featureToggles.hmctsLinkAndGuestPin)
   njkEnv.addGlobal('bulkPrintMovementSlipsEnabled', config.featureBulkPrintMovementSlips)
 }

--- a/server/views/pages/dailySchedule/dailySchedule.njk
+++ b/server/views/pages/dailySchedule/dailySchedule.njk
@@ -152,7 +152,7 @@
                             classes: classes
                         },
                         {
-                            html: (toCourtLink(scheduleItem, hmctsLinkAndGuestPinEnabled) if scheduleItem.videoLinkRequired) or (('--' if appointmentGroup.length == 1) + '<span class="govuk-visually-hidden">Not required</span>'),
+                            html: (toCourtLink(scheduleItem) if scheduleItem.videoLinkRequired) or (('--' if appointmentGroup.length == 1) + '<span class="govuk-visually-hidden">Not required</span>'),
                             classes: classes,
                             attributes: {
                               'width': '10%',

--- a/server/views/partials/toCourtLink.njk
+++ b/server/views/partials/toCourtLink.njk
@@ -1,28 +1,28 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{# Macro to format the CVP link based on known information and the feature switch value #}
+{# Macro to format the CVP link based on known information #}
 
-{% macro toCourtLink(item, feature) %}
-    {% if feature and item.hmctsNumber %}
+{% macro toCourtLink(item) %}
+    {% if item.hmctsNumber %}
       {# If the HMCTS number is present construct a full, clickable link to join the meeting #}
       <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word"
          href="{{ (item.hmctsNumber | toFullCourtLink) }}"
          rel="noreferrer noopener" target="_blank">
         HMCTS{{ item.hmctsNumber }}
       </a>
-    {% elseif feature and item.videoLink and (item.videoLink | isValidUrl) %}
+    {% elseif item.videoLink and (item.videoLink | isValidUrl) %}
       {# If valid URL is present construct a clickable link to this URL with the link text "Court link" #}
       <a class="govuk-link govuk-link--no-visited-state govuk-!-text-break-word"
          href="{{ item.videoLink }}"
          rel="noreferrer noopener" target="_blank">
         Court link
       </a>
-    {% elseif feature and item.videoLink and not (item.videoLink | isValidUrl) and item.videoLink.length <= 35 %}
+    {% elseif item.videoLink and not (item.videoLink | isValidUrl) and item.videoLink.length <= 35 %}
         {# If videoLink is present but is not a valid URL but is under 35 chars show the value in plain text #}
         <div class="govuk-body-s">
             {{ item.videoLink }}
         </div>
-    {% elseif feature and item.videoLink and not (item.videoLink | isValidUrl) and item.videoLink.length > 35 %}
+    {% elseif item.videoLink and not (item.videoLink | isValidUrl) and item.videoLink.length > 35 %}
         {# If the link is present but not a valid URL and is over 35 chars show a details component #}
         {{ govukDetails({
            summaryText: "Check booking",
@@ -31,7 +31,7 @@
            classes: "govuk-body-s"
         }) }}
     {% elseif item.videoLink %}
-      {# Default if present and feature is off #}
+      {# Default if present #}
       {{ item.videoLink }}
     {% else %}
       None entered


### PR DESCRIPTION
Guest PIN / link functionality has now been live long enough to warrant the removal of the feature toggle code that sits around it.