### PR TITLE
BAVL-1090 include the prisoners cell location on the movement slip.

### DIFF
--- a/server/routes/journeys/dailySchedule/handlers/movementSlips.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/movementSlips.test.ts
@@ -115,7 +115,7 @@ describe('GET with feature toggle on', () => {
           'Moorland (HMP) Video appointment movement authorisation slip',
         )
         expect(getByDataQa($, 'date').text()).toEqual('20 July 2055')
-        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Joe Bloggs, ABC123')
+        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Joe Bloggs, ABC123, [A-1-001]')
         expect(getByDataQa($, 'pre-court-hearing').text()).toContain('07:45')
         expect(getByDataQa($, 'court-hearing---appeal').text()).toContain('08:00')
         expect(getByDataQa($, 'pick-up-time').text()).toContain('07:15')
@@ -172,7 +172,7 @@ describe('GET with feature toggle on', () => {
           'Moorland (HMP) Video appointment movement authorisation slip',
         )
         expect(getByDataQa($, 'date').text()).toEqual('19 July 2055')
-        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Fred Flintrock, FRE123')
+        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Fred Flintrock, FRE123, [P-1-001]')
         expect(getByDataQa($, 'probation-meeting---other').text()).toContain('10:00')
         expect(getByDataQa($, 'pick-up-time').text()).toContain('09:30')
         expect(getByDataQa($, 'location').text()).toContain('PROBATION ROOM')
@@ -224,7 +224,7 @@ describe('GET with feature toggle on', () => {
           'Moorland (HMP) Video appointment movement authorisation slip',
         )
         expect(getByDataQa($, 'date').text()).toEqual('18 July 2055')
-        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Wilma Flintrock, WIL123')
+        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Wilma Flintrock, WIL123, [W-001]')
         expect(getByDataQa($, 'another-prison').text()).toContain('14:30')
         expect(getByDataQa($, 'pick-up-time').text()).toContain('14:00')
         expect(getByDataQa($, 'location').text()).toContain('In Cell')
@@ -247,7 +247,7 @@ describe('GET with feature toggle on', () => {
             appointmentLocationDescription: 'In Cell',
             lastUpdatedOrCreated: startOfToday().toISOString(),
             prisoner: {
-              cellLocation: 'W-001',
+              cellLocation: 'W-002',
               firstName: 'Barney',
               hasAlerts: false,
               inPrison: true,
@@ -276,7 +276,7 @@ describe('GET with feature toggle on', () => {
           'Moorland (HMP) Video appointment movement authorisation slip',
         )
         expect(getByDataQa($, 'date').text()).toEqual('17 July 2055')
-        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Barney Rabble, BAR123')
+        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Barney Rabble, BAR123, [W-002]')
         expect(getByDataQa($, 'legal-appointment').text()).toContain('16:30')
         expect(getByDataQa($, 'pick-up-time').text()).toContain('16:00')
         expect(getByDataQa($, 'location').text()).toContain('In Cell')
@@ -299,7 +299,7 @@ describe('GET with feature toggle on', () => {
             appointmentLocationDescription: 'In Cell',
             lastUpdatedOrCreated: startOfToday().toISOString(),
             prisoner: {
-              cellLocation: 'W-001',
+              cellLocation: 'X-001',
               firstName: 'Betty',
               hasAlerts: false,
               inPrison: true,
@@ -328,7 +328,7 @@ describe('GET with feature toggle on', () => {
           'Moorland (HMP) Video appointment movement authorisation slip',
         )
         expect(getByDataQa($, 'date').text()).toEqual('16 July 2055')
-        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Betty Rabble, BET123')
+        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Betty Rabble, BET123, [X-001]')
         expect(getByDataQa($, 'official-other').text()).toContain('15:15')
         expect(getByDataQa($, 'pick-up-time').text()).toContain('14:45')
         expect(getByDataQa($, 'location').text()).toContain('In Cell')
@@ -351,7 +351,7 @@ describe('GET with feature toggle on', () => {
             appointmentLocationDescription: 'In Cell',
             lastUpdatedOrCreated: startOfToday().toISOString(),
             prisoner: {
-              cellLocation: 'W-001',
+              cellLocation: 'D-055',
               firstName: 'Don',
               hasAlerts: false,
               inPrison: true,
@@ -380,7 +380,7 @@ describe('GET with feature toggle on', () => {
           'Moorland (HMP) Video appointment movement authorisation slip',
         )
         expect(getByDataQa($, 'date').text()).toEqual('16 July 2055')
-        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Don Key, DON123')
+        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Don Key, DON123, [D-055]')
         expect(getByDataQa($, 'parole-hearing').text()).toContain('09:15')
         expect(getByDataQa($, 'pick-up-time').text()).toContain('08:45')
         expect(getByDataQa($, 'location').text()).toContain('In Cell')
@@ -403,7 +403,7 @@ describe('GET with feature toggle on', () => {
             appointmentLocationDescription: 'In Cell',
             lastUpdatedOrCreated: startOfToday().toISOString(),
             prisoner: {
-              cellLocation: 'W-001',
+              cellLocation: 'D-055',
               firstName: 'Don',
               hasAlerts: false,
               inPrison: true,
@@ -432,7 +432,7 @@ describe('GET with feature toggle on', () => {
           'Moorland (HMP) Video appointment movement authorisation slip',
         )
         expect(getByDataQa($, 'date').text()).toEqual(formatDate(startOfToday()))
-        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Don Key, DON123')
+        expect(getByDataQa($, 'prisoner-name-and-number').text()).toContain('Don Key, DON123, [D-055]')
         expect(getByDataQa($, 'parole-hearing').text()).toContain('09:15')
         expect(getByDataQa($, 'pick-up-time').text()).toContain('08:45')
         expect(getByDataQa($, 'location').text()).toContain('In Cell')

--- a/server/routes/journeys/dailySchedule/handlers/movementSlips.ts
+++ b/server/routes/journeys/dailySchedule/handlers/movementSlips.ts
@@ -38,49 +38,52 @@ export default class MovementSlipsHandler implements PageHandler {
   }
 
   private convertToMovementSlips = (schedule: DailySchedule, prison: Prison, date: Date) => {
-    return schedule.appointmentGroups.map(group => ({
-      prisonName: prison.name,
-      prisonerName: convertToTitleCase(`${group[0].prisoner.firstName} ${group[0].prisoner.lastName}`),
-      prisonerNumber: group[0].prisoner.prisonerNumber,
-      date,
-      anotherPrison: this.isAppointmentType(AppointmentType.ANOTHER_PRISON, group)
-        ? {
-            startTime: this.getStartTime(group, AppointmentType.ANOTHER_PRISON),
-          }
-        : undefined,
-      court: this.isAppointmentType(AppointmentType.COURT, group)
-        ? {
-            preStartTime: this.getStartTime(group, AppointmentType.COURT, 'Pre-hearing'),
-            startTime: this.getStartTime(group, AppointmentType.COURT, 'Court Hearing'),
-            postStartTime: this.getStartTime(group, AppointmentType.COURT, 'Post-hearing'),
-            hearingType: this.getHearingType(group),
-          }
-        : undefined,
-      legal: this.isAppointmentType(AppointmentType.LEGAL, group)
-        ? {
-            startTime: this.getStartTime(group, AppointmentType.LEGAL),
-          }
-        : undefined,
-      parole: this.isAppointmentType(AppointmentType.PAROLE, group)
-        ? {
-            startTime: this.getStartTime(group, AppointmentType.PAROLE),
-          }
-        : undefined,
-      probation: this.isAppointmentType(AppointmentType.PROBATION, group)
-        ? {
-            startTime: this.getStartTime(group, AppointmentType.PROBATION),
-            meetingType: this.getMeetingType(group),
-          }
-        : undefined,
-      officialOther: this.isAppointmentType(AppointmentType.OFFICIAL_OTHER, group)
-        ? {
-            startTime: this.getStartTime(group, AppointmentType.OFFICIAL_OTHER),
-          }
-        : undefined,
-      pickUpTime: prison.pickUpTime ? removeMinutes(group[0].startTime, prison.pickUpTime) : undefined,
-      location: this.getLocation(group),
-      notes: group[0].notesForPrisoner,
-    }))
+    return schedule.appointmentGroups
+      .map(group => ({
+        prisonName: prison.name,
+        prisonerName: convertToTitleCase(`${group[0].prisoner.firstName} ${group[0].prisoner.lastName}`),
+        prisonerNumber: group[0].prisoner.prisonerNumber,
+        prisonerCellLocation: group[0].prisoner.cellLocation,
+        date,
+        anotherPrison: this.isAppointmentType(AppointmentType.ANOTHER_PRISON, group)
+          ? {
+              startTime: this.getStartTime(group, AppointmentType.ANOTHER_PRISON),
+            }
+          : undefined,
+        court: this.isAppointmentType(AppointmentType.COURT, group)
+          ? {
+              preStartTime: this.getStartTime(group, AppointmentType.COURT, 'Pre-hearing'),
+              startTime: this.getStartTime(group, AppointmentType.COURT, 'Court Hearing'),
+              postStartTime: this.getStartTime(group, AppointmentType.COURT, 'Post-hearing'),
+              hearingType: this.getHearingType(group),
+            }
+          : undefined,
+        legal: this.isAppointmentType(AppointmentType.LEGAL, group)
+          ? {
+              startTime: this.getStartTime(group, AppointmentType.LEGAL),
+            }
+          : undefined,
+        parole: this.isAppointmentType(AppointmentType.PAROLE, group)
+          ? {
+              startTime: this.getStartTime(group, AppointmentType.PAROLE),
+            }
+          : undefined,
+        probation: this.isAppointmentType(AppointmentType.PROBATION, group)
+          ? {
+              startTime: this.getStartTime(group, AppointmentType.PROBATION),
+              meetingType: this.getMeetingType(group),
+            }
+          : undefined,
+        officialOther: this.isAppointmentType(AppointmentType.OFFICIAL_OTHER, group)
+          ? {
+              startTime: this.getStartTime(group, AppointmentType.OFFICIAL_OTHER),
+            }
+          : undefined,
+        pickUpTime: prison.pickUpTime ? removeMinutes(group[0].startTime, prison.pickUpTime) : undefined,
+        location: this.getLocation(group),
+        notes: group[0].notesForPrisoner,
+      }))
+      .sort((a, b) => a.prisonerCellLocation.localeCompare(b.prisonerCellLocation))
   }
 
   private isAppointmentType = (appointmentType: AppointmentType, group: ScheduleItem[]) => {

--- a/server/views/partials/movementSlip.njk
+++ b/server/views/partials/movementSlip.njk
@@ -8,7 +8,7 @@
 
     <div class="movement-slip">
         <h1 data-qa='movement-slip-header' class='movement-slip-header'>{{ movementSlip.prisonName }} <span class='govuk-body-m'>Video appointment movement authorisation slip</span></h1>
-        <h1 data-qa='prisoner-name-and-number' class='govuk-heading-s'>{{ movementSlip.prisonerName }}, {{ movementSlip.prisonerNumber }}</h1>
+        <h1 data-qa='prisoner-name-and-number' class='govuk-heading-s'>{{ movementSlip.prisonerName }}, {{ movementSlip.prisonerNumber }}, [{{ movementSlip.prisonerCellLocation }}]</h1>
         <dl class='movement-slip__summary'>
             {{ labelAndValue('Date', movementSlip.date | formatDate("d MMMM yyyy")) }}
         </dl>


### PR DESCRIPTION
Include the (missing) cell location on the movement slip so know where to pick the prisoner up from.

The slips are sorted by cell location.

<img width="2458" height="2444" alt="image" src="https://github.com/user-attachments/assets/c54831af-1569-4e3e-84a2-1b2f32c00bd4" />

<img width="1530" height="1968" alt="image" src="https://github.com/user-attachments/assets/af4a87a9-0b4e-4a28-9757-c0734edd0cde" />
