### PR TITLE
BAVL-1280 pinning github actions to specific SHA versions for security and .npmrc security improvements.

### DIFF
--- a/.github/workflows/node_integration_tests_redis.yml
+++ b/.github/workflows/node_integration_tests_redis.yml
@@ -19,18 +19,18 @@ jobs:
           - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Use Node.js ${{ inputs.node_version_file }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ${{ inputs.node_version_file }}
       - name: download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: npm_build_artifacts
       - name: restore cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
           cache-name: node-modules
         with:
@@ -54,7 +54,7 @@ jobs:
           npm run int-test
       - name: upload results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: npm_integration_test_artifacts
           path: |
@@ -65,7 +65,7 @@ jobs:
             ctrf/
       - name: publish test report
         if: ${{ !cancelled() && github.event.repository.visibility == 'public' }}
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
         with:
           artifact: npm_integration_test_artifacts
           name: Test Report
@@ -77,7 +77,7 @@ jobs:
           list-tests: 'failed'
       - name: fail the action if the tests failed
         if: ${{ steps.integration-tests.outcome == 'failure' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             core.setFailed('Integration tests failed')

--- a/.npmrc
+++ b/.npmrc
@@ -11,3 +11,9 @@ engine-strict = true
 
 # Show any output of scripts in the console 
 foreground-scripts = true
+
+# Wait a minimum of 7 days before allowing a package to be released, this is to allow time for any issues to be discovered and fixed before the package is released
+min-release-age = 7
+
+# Don't allow git dependencies see here. These can allow malicious actors to alias common executables with nefarious versions
+allow-git = none


### PR DESCRIPTION
As well as pinning the SHA actions this change also improves the .npmrc security as per the TypeScript template project.