### PR TITLE
BAVL-1298 security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9973,41 +9973,46 @@
       }
     },
     "node_modules/grunt-legacy-log": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-3.0.1.tgz",
+      "integrity": "sha512-vytI3IUC8qUK9TcvvpHpGJzDojua/sfJV4TdLB4FtCFzospqduzBuL3+dEfpvO+tGECv7/273+33hjjMXSa92g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "colors": "~1.1.2",
-        "grunt-legacy-log-utils": "~2.1.0",
+        "grunt-legacy-log-utils": "^2.1.3",
         "hooker": "~0.2.3",
-        "lodash": "~4.17.19"
+        "lodash": "^4.18.0"
       },
       "engines": {
         "node": ">= 0.10.0"
       }
     },
     "node_modules/grunt-legacy-log-utils": {
-      "version": "2.1.0",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.1.3.tgz",
+      "integrity": "sha512-sgG+QvKmdb44wZyzJP+ejDsy3jYxG2wzohpol+JTMlXqMUBDoZb01JPQ5jKAedtZBFwhmABAc88T9hEBLy3U+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "~4.1.0",
-        "lodash": "~4.17.19"
+        "chalk": "^4.1.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/grunt-legacy-util": {
-      "version": "2.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-2.0.2.tgz",
+      "integrity": "sha512-0xoDILyR4BVJel5uJwnhjdWN9evOQ8A0uXbQUIJ0hgVthIA6kloXHSoqATQPj6BRrHrHkcQtCeGVb0ixFoHyEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "async": "~3.2.0",
-        "exit": "~0.1.2",
+        "exit-x": "~0.2.2",
         "getobject": "~1.0.0",
         "hooker": "~0.2.3",
-        "lodash": "~4.17.21",
+        "lodash": "^4.18.0",
         "underscore.string": "~3.3.5",
         "which": "~2.0.2"
       },
@@ -14399,9 +14404,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {


### PR DESCRIPTION
Resolves the following:

```
=== npm audit security report ===                                    
+---------+--------+---------------------+----------+---------------------------------------------------+
| ID      | Module | Paths               | Severity | URL                                               |
+---------+--------+---------------------+----------+---------------------------------------------------+
| 1115806 | lodash | node_modules/lodash | high     | https://github.com/advisories/GHSA-r5fr-rjxr-66jc |
| 1115810 | lodash | node_modules/lodash | moderate | https://github.com/advisories/GHSA-f23m-r3pf-42rh |
+---------+--------+---------------------+----------+---------------------------------------------------+
```