### PR TITLE
BAVL-1341 add feature toggle for inclusion/exclusion of staff notes in the CSV download.

### DIFF
--- a/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
+++ b/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
@@ -34,6 +34,7 @@ generic-service:
     AUDIT_SQS_REGION: "eu-west-2"
     AUDIT_SERVICE_NAME: "hmpps-video-conference-schedule-ui"
     FEATURE_TEMPORARY_BLOCKING_LOCATIONS: "false"
+    FEATURE_INCLUDE_STAFF_NOTES_IN_CSV_DOWNLOAD: "false"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,6 +24,7 @@ generic-service:
     PRISON_API_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
+    FEATURE_INCLUDE_STAFF_NOTES_IN_CSV_DOWNLOAD: "true"
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/server/config.ts
+++ b/server/config.ts
@@ -185,5 +185,6 @@ export default {
   applicationInsightsConnectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', '', requiredInProduction),
   featureToggles: {
     temporaryBlockingLocations: get('FEATURE_TEMPORARY_BLOCKING_LOCATIONS', false) === 'true',
+    includeStaffNotesInCsvDownload: get('FEATURE_INCLUDE_STAFF_NOTES_IN_CSV_DOWNLOAD', false) === 'true',
   },
 }

--- a/server/routes/journeys/dailySchedule/handlers/downloadCsvHandlerDeprecated.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/downloadCsvHandlerDeprecated.test.ts
@@ -9,7 +9,6 @@ import {
 } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import ScheduleService, { DailySchedule } from '../../../../services/scheduleService'
-import config from '../../../../config'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/scheduleService')
@@ -30,28 +29,26 @@ const appSetup = (journeySession = {}, prisonSupplier = moorlandPrisonPickUpTime
 }
 
 const expectedCsvNoPickupTimes =
-  'Prisoner name,Prison number,Cell number,Appointment start time,Appointment end time,Appointment type,Appointment subtype,Room location,Court or probation team,Video link,Last updated,Probation officer name,Staff notes' +
-  '\nSmith John,ABC123,A-1-001,10:45,11:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,,' +
-  '\nSmith John,ABC123,A-1-001,11:00,12:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,,Court hearing staff notes' +
-  '\nDoe John,DEF123,B-1-001,11:00,12:00,Court Hearing,,B Wing Video Link,,HMCTS 54321,10 December 2024 at 00:00,,' +
-  '\nDoe Jane,HIJ123,C-1-001,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00,,' +
-  '\nBat Man,RR9100,R-1-9000,13:00,13:30,Probation Meeting,,X Wing Video Link,,,,Not yet known,' +
-  '\nFlintrock Fred,BC5000,B-1-5000,16:00,17:00,Court Hearing,,Z Wing Video Link,,,,,' +
-  '\nLawless Lucy,ZZ5000,X-1-4000,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name,"Probation meeting staff notes with special characters, "" \' À"'
+  'Prisoner name,Prison number,Cell number,Appointment start time,Appointment end time,Appointment type,Appointment subtype,Room location,Court or probation team,Video link,Last updated,Probation officer name' +
+  '\nSmith John,ABC123,A-1-001,10:45,11:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,' +
+  '\nSmith John,ABC123,A-1-001,11:00,12:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,' +
+  '\nDoe John,DEF123,B-1-001,11:00,12:00,Court Hearing,,B Wing Video Link,,HMCTS 54321,10 December 2024 at 00:00,' +
+  '\nDoe Jane,HIJ123,C-1-001,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00,' +
+  '\nBat Man,RR9100,R-1-9000,13:00,13:30,Probation Meeting,,X Wing Video Link,,,,Not yet known' +
+  '\nFlintrock Fred,BC5000,B-1-5000,16:00,17:00,Court Hearing,,Z Wing Video Link,,,,' +
+  '\nLawless Lucy,ZZ5000,X-1-4000,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name'
 
 const expectedCsvWithPickupTimes =
-  'Prisoner name,Prison number,Cell number,Pick-up time,Appointment start time,Appointment end time,Appointment type,Appointment subtype,Room location,Court or probation team,Video link,Last updated,Probation officer name,Staff notes' +
-  '\nSmith John,ABC123,A-1-001,10:15,10:45,11:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,,' +
-  '\nSmith John,ABC123,A-1-001,,11:00,12:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,,Court hearing staff notes' +
-  '\nDoe John,DEF123,B-1-001,10:30,11:00,12:00,Court Hearing,,B Wing Video Link,,HMCTS 54321,10 December 2024 at 00:00,,' +
-  '\nDoe Jane,HIJ123,C-1-001,10:30,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00,,' +
-  '\nBat Man,RR9100,R-1-9000,12:30,13:00,13:30,Probation Meeting,,X Wing Video Link,,,,Not yet known,' +
-  '\nFlintrock Fred,BC5000,B-1-5000,15:30,16:00,17:00,Court Hearing,,Z Wing Video Link,,,,,' +
-  '\nLawless Lucy,ZZ5000,X-1-4000,15:30,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name,"Probation meeting staff notes with special characters, "" \' À"'
+  'Prisoner name,Prison number,Cell number,Pick-up time,Appointment start time,Appointment end time,Appointment type,Appointment subtype,Room location,Court or probation team,Video link,Last updated,Probation officer name' +
+  '\nSmith John,ABC123,A-1-001,10:15,10:45,11:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,' +
+  '\nSmith John,ABC123,A-1-001,,11:00,12:00,Court Hearing,,A Wing Video Link,,http://video.url,10 December 2024 at 00:00,' +
+  '\nDoe John,DEF123,B-1-001,10:30,11:00,12:00,Court Hearing,,B Wing Video Link,,HMCTS 54321,10 December 2024 at 00:00,' +
+  '\nDoe Jane,HIJ123,C-1-001,10:30,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00,' +
+  '\nBat Man,RR9100,R-1-9000,12:30,13:00,13:30,Probation Meeting,,X Wing Video Link,,,,Not yet known' +
+  '\nFlintrock Fred,BC5000,B-1-5000,15:30,16:00,17:00,Court Hearing,,Z Wing Video Link,,,,' +
+  '\nLawless Lucy,ZZ5000,X-1-4000,15:30,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name'
 
 beforeEach(() => {
-  config.featureToggles.includeStaffNotesInCsvDownload = true
-
   scheduleService.getSchedule.mockResolvedValue({
     appointmentGroups: [
       [
@@ -76,7 +73,6 @@ beforeEach(() => {
           videoLink: 'http://video.url',
           videoLinkRequired: true,
           videoLinkId: 1,
-          notesForStaff: 'Court hearing staff notes',
         },
       ],
       [
@@ -135,7 +131,6 @@ beforeEach(() => {
           lastUpdatedOrCreated: undefined,
           videoLinkRequired: true,
           probationOfficerName: 'Probation Officer Name',
-          notesForStaff: 'Probation meeting staff notes with special characters, " \' À',
         },
       ],
     ],

--- a/server/routes/journeys/dailySchedule/handlers/downloadCsvHandlerDeprecated.ts
+++ b/server/routes/journeys/dailySchedule/handlers/downloadCsvHandlerDeprecated.ts
@@ -1,0 +1,103 @@
+import * as converter from 'json-2-csv'
+import { Request, Response } from 'express'
+import { isValid, startOfDay } from 'date-fns'
+import { Page } from '../../../../services/auditService'
+import { PageHandler } from '../../../interfaces/pageHandler'
+import ScheduleService, { DailySchedule, ScheduleItem } from '../../../../services/scheduleService'
+import { convertToTitleCase, formatDate, removeMinutes, toFullCourtLinkPrint } from '../../../../utils/utils'
+
+export default class DownloadCsvHandlerDeprecated implements PageHandler {
+  public PAGE_NAME = Page.DOWNLOAD_DAILY_SCHEDULE
+
+  constructor(private readonly scheduleService: ScheduleService) {}
+
+  GET = async (req: Request, res: Response) => {
+    const prison = req.middleware!.prison!
+    const { user } = res.locals
+    const filters = req.session.journey?.scheduleFilters
+
+    const dateFromQueryParam = new Date(req.query.date?.toString())
+    const statusFromQueryParam = req.query.status as 'ACTIVE' | 'CANCELLED'
+
+    const date = startOfDay(isValid(dateFromQueryParam) ? dateFromQueryParam : new Date())
+    const status = ['ACTIVE', 'CANCELLED'].includes(statusFromQueryParam) ? statusFromQueryParam : 'ACTIVE'
+
+    const schedule = await this.scheduleService.getSchedule(
+      user.activeCaseLoadId,
+      startOfDay(isValid(date) ? date : new Date()),
+      filters,
+      status,
+      user,
+    )
+
+    const csv = prison.pickUpTime
+      ? converter.json2csv(this.convertScheduleToCsvRowsWithPickUpTimes(schedule, prison.pickUpTime))
+      : converter.json2csv(this.convertScheduleToCsvRows(schedule))
+
+    res.header('Content-Type', 'text/csv')
+    res.attachment(`daily-schedule${status === 'CANCELLED' ? '-cancelled' : ''}-${formatDate(date, 'yyyy-MM-dd')}.csv`)
+    res.send(csv)
+  }
+
+  private convertScheduleToCsvRows = (schedule: DailySchedule) => {
+    return schedule.appointmentGroups.flatMap(group =>
+      group.map(item => ({
+        'Prisoner name': convertToTitleCase(`${item.prisoner.lastName} ${item.prisoner.firstName}`),
+        'Prison number': item.prisoner.prisonerNumber,
+        'Cell number': item.prisoner.cellLocation,
+        'Appointment start time': item.startTime,
+        'Appointment end time': item.endTime || '',
+        'Appointment type': item.appointmentTypeDescription,
+        'Appointment subtype': item.appointmentSubtypeDescription || '',
+        'Room location': item.appointmentLocationDescription,
+        'Court or probation team': item.externalAgencyDescription || '',
+        'Video link': this.courtLinkFor(item) || '',
+        'Last updated': item.lastUpdatedOrCreated
+          ? formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm")
+          : '',
+        'Probation officer name': this.probationOfficerNameOrUndefined(item) || '',
+      })),
+    )
+  }
+
+  private convertScheduleToCsvRowsWithPickUpTimes = (schedule: DailySchedule, pickUpTime: number) => {
+    return schedule.appointmentGroups.flatMap(group =>
+      group.map((item, index) => ({
+        'Prisoner name': convertToTitleCase(`${item.prisoner.lastName} ${item.prisoner.firstName}`),
+        'Prison number': item.prisoner.prisonerNumber,
+        'Cell number': item.prisoner.cellLocation,
+        'Pick-up time': index === 0 ? removeMinutes(item.startTime, pickUpTime) : '',
+        'Appointment start time': item.startTime,
+        'Appointment end time': item.endTime || '',
+        'Appointment type': item.appointmentTypeDescription,
+        'Appointment subtype': item.appointmentSubtypeDescription || '',
+        'Room location': item.appointmentLocationDescription,
+        'Court or probation team': item.externalAgencyDescription || '',
+        'Video link': this.courtLinkFor(item) || '',
+        'Last updated': item.lastUpdatedOrCreated
+          ? formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm")
+          : '',
+        'Probation officer name': this.probationOfficerNameOrUndefined(item) || '',
+      })),
+    )
+  }
+
+  private courtLinkFor = (item: ScheduleItem) => {
+    if (item.videoLinkRequired) {
+      if (item.videoLink) {
+        return item.videoLink
+      }
+      if (item.hmctsNumber) {
+        return toFullCourtLinkPrint(item.hmctsNumber)
+      }
+    }
+
+    return undefined
+  }
+
+  private probationOfficerNameOrUndefined = (item: ScheduleItem) => {
+    return item.appointmentTypeDescription === 'Probation Meeting'
+      ? item.probationOfficerName || 'Not yet known'
+      : undefined
+  }
+}

--- a/server/routes/journeys/dailySchedule/index.ts
+++ b/server/routes/journeys/dailySchedule/index.ts
@@ -8,6 +8,8 @@ import logPageViewMiddleware from '../../../middleware/logPageViewMiddleware'
 import validationMiddleware from '../../../middleware/validationMiddleware'
 import DownloadCsvHandler from './handlers/downloadCsvHandler'
 import MovementSlipsHandler from './handlers/movementSlips'
+import config from '../../../config'
+import DownloadCsvHandlerDeprecated from './handlers/downloadCsvHandlerDeprecated'
 
 export default function Index({
   auditService,
@@ -29,7 +31,15 @@ export default function Index({
 
   getAndPost('/', new DailyScheduleHandler(referenceDataService, prisonService, scheduleService))
   get('/clear-filter', new ClearFilterHandler())
-  get('/download-csv', new DownloadCsvHandler(scheduleService))
+
+  // This feature toggle is temporary and will be removed once the feature has been turned on
+  if (config.featureToggles.includeStaffNotesInCsvDownload) {
+    get('/download-csv', new DownloadCsvHandler(scheduleService))
+  } else {
+    // Can be removed once the feature has been turned on
+    get('/download-csv', new DownloadCsvHandlerDeprecated(scheduleService))
+  }
+
   getAndPost('/select-date', new SelectDateHandler())
   get('/movement-slips', new MovementSlipsHandler(scheduleService))
 


### PR DESCRIPTION
The deprecated files in this PR are the original download handers prior to the introduction of the staff download.  These are used when the toggle is false, otherwise the replacement handler is used.