### PR TITLE
BAVL-1352 include basic official visit rows in the Daily Schedule. The filter does not yet support this and view/edit link missing.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -25,6 +25,7 @@ generic-service:
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     OFFICIAL_VISITS_API_URL: "https://official-visits-api-dev.hmpps.service.justice.gov.uk"
+    OFFICIAL_VISITS_URL: "https://official-visits-ui-dev.hmpps.service.justice.gov.uk"
     FEATURE_INCLUDE_OFFICIAL_VISITS: "true"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,6 +25,7 @@ generic-service:
     PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
     OFFICIAL_VISITS_API_URL: "https://official-visits-api-preprod.hmpps.service.justice.gov.uk"
+    OFFICIAL_VISITS_URL: "https://official-visits-ui-preprod.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,6 +22,7 @@ generic-service:
     PRISON_REGISTER_API_URL: "https://prison-register.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-search.prison.service.justice.gov.uk"
     OFFICIAL_VISITS_API_URL: "https://official-visits-api.hmpps.service.justice.gov.uk"
+    OFFICIAL_VISITS_URL: "https://official-visits-ui.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-book-a-video-link-prod

--- a/server/config.ts
+++ b/server/config.ts
@@ -188,6 +188,7 @@ export default {
   },
   dpsUrl: get('DPS_URL', 'http://localhost:3000', requiredInProduction),
   activitiesAndAppointmentsUrl: get('ACTIVITIES_AND_APPOINTMENTS_URL', 'http://localhost:3000', requiredInProduction),
+  officialVisitsUrl: get('OFFICIAL_VISITS_URL', 'http://localhost:3000', requiredInProduction),
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
   feedbackUrl: get('FEEDBACK_URL', '#'),

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -15,6 +15,7 @@ import PrisonerSearchApiClient from './prisonerSearchApiClient'
 import NomisMappingApiClient from './nomisMappingApiClient'
 import ActivitiesAndAppointmentsApiClient from './activitiesAndAppointmentsApiClient'
 import LocationsInsidePrisonApiClient from './locationsInsidePrisonApiClient'
+import OfficialVisitsApiClient from './officialVisitsApiClient'
 
 const applicationInfo = applicationInfoSupplier()
 initialiseAppInsights()
@@ -32,6 +33,7 @@ export const dataAccess = () => ({
   prisonRegisterApiClient: new PrisonRegisterApiClient(),
   prisonerSearchApiClient: new PrisonerSearchApiClient(),
   locationsInsidePrisonApiClient: new LocationsInsidePrisonApiClient(),
+  officialVisitsApiClient: new OfficialVisitsApiClient(),
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/data/officialVisitsApiClient.test.ts
+++ b/server/data/officialVisitsApiClient.test.ts
@@ -36,6 +36,7 @@ describe('prisonApiClient', () => {
         .post(`/official-visit/prison/${prisonCode}/find-by-criteria?page=0&size=200`, {
           startDate: onDate,
           endDate: onDate,
+          visitTypes: ['VIDEO'],
         } as RequestBodyMatcher)
         .matchHeader('authorization', 'Bearer systemToken')
         .reply(200, mockOfficialVisitSearchResults)

--- a/server/data/officialVisitsApiClient.ts
+++ b/server/data/officialVisitsApiClient.ts
@@ -20,6 +20,7 @@ export default class OfficialVisitsApiClient extends RestClient {
         data: {
           startDate: formatDate(onDate, 'yyyy-MM-dd'),
           endDate: formatDate(onDate, 'yyyy-MM-dd'),
+          visitTypes: ['VIDEO'],
         } as OfficialVisitSearchCriteria,
       },
       user,

--- a/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
@@ -24,7 +24,7 @@ jest.mock('../../../../services/scheduleService')
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const referenceDataService = new ReferenceDataService(null, null, null) as jest.Mocked<ReferenceDataService>
 const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
-const scheduleService = new ScheduleService(null, null, null, null, null, null) as jest.Mocked<ScheduleService>
+const scheduleService = new ScheduleService(null, null, null, null, null, null, null) as jest.Mocked<ScheduleService>
 
 let app: Express
 const filters = { wing: ['A'] }

--- a/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/scheduleService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
-const scheduleService = new ScheduleService(null, null, null, null, null, null) as jest.Mocked<ScheduleService>
+const scheduleService = new ScheduleService(null, null, null, null, null, null, null) as jest.Mocked<ScheduleService>
 
 let app: Express
 const filters = { wing: ['A'] }

--- a/server/routes/journeys/dailySchedule/handlers/movementSlips.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/movementSlips.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../../../services/scheduleService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
-const scheduleService = new ScheduleService(null, null, null, null, null, null) as jest.Mocked<ScheduleService>
+const scheduleService = new ScheduleService(null, null, null, null, null, null, null) as jest.Mocked<ScheduleService>
 
 let app: Express
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -4,6 +4,7 @@ import PrisonService from './prisonService'
 import ScheduleService from './scheduleService'
 import AppointmentService from './appointmentService'
 import ReferenceDataService from './referenceDataService'
+import OfficialVisitsService from './officialVisitsService'
 
 export const services = () => {
   const {
@@ -17,6 +18,7 @@ export const services = () => {
     prisonerSearchApiClient,
     activitiesAndAppointmentsApiClient,
     locationsInsidePrisonApiClient,
+    officialVisitsApiClient,
   } = dataAccess()
 
   const auditService = new AuditService(hmppsAuditClient)
@@ -31,6 +33,7 @@ export const services = () => {
     activitiesAndAppointmentsApiClient,
     bookAVideoLinkApiClient,
   )
+  const officialVisitsService = new OfficialVisitsService(officialVisitsApiClient)
   const scheduleService = new ScheduleService(
     appointmentService,
     referenceDataService,
@@ -38,6 +41,7 @@ export const services = () => {
     bookAVideoLinkApiClient,
     prisonerSearchApiClient,
     manageUsersApiClient,
+    officialVisitsService,
   )
 
   return {

--- a/server/services/scheduleService.test.ts
+++ b/server/services/scheduleService.test.ts
@@ -12,6 +12,9 @@ import NomisMappingApiClient from '../data/nomisMappingApiClient'
 import ManageUsersApiClient from '../data/manageUsersApiClient'
 import { User } from '../@types/manageUsersApi/types'
 import ReferenceDataService, { CellsByWing } from './referenceDataService'
+import OfficialVisitsService from './officialVisitsService'
+import { OfficialVisit } from '../@types/officialVisitsApi/types'
+import config from '../config'
 
 jest.mock('../services/appointmentService')
 jest.mock('../services/referenceDataService')
@@ -19,6 +22,7 @@ jest.mock('../data/nomisMappingApiClient')
 jest.mock('../data/bookAVideoLinkApiClient')
 jest.mock('../data/prisonerSearchApiClient')
 jest.mock('../data/manageUsersApiClient')
+jest.mock('../services/officialVisitsService')
 
 const user = createUser([])
 
@@ -29,12 +33,14 @@ describe('Schedule service', () => {
   let bookAVideoLinkApiClient: jest.Mocked<BookAVideoLinkApiClient>
   let prisonerSearchApiClient: jest.Mocked<PrisonerSearchApiClient>
   let manageUsersApiClient: jest.Mocked<ManageUsersApiClient>
+  let officialVisitsService: jest.Mocked<OfficialVisitsService>
 
   let scheduleService: ScheduleService
 
   let appointments: Appointment[]
   let bvlsAppointments: BvlsAppointment[]
   let prisoners: Prisoner[]
+  let officialVisits: OfficialVisit[]
 
   beforeEach(() => {
     appointmentService = new AppointmentService(null, null, null) as jest.Mocked<AppointmentService>
@@ -43,6 +49,7 @@ describe('Schedule service', () => {
     bookAVideoLinkApiClient = new BookAVideoLinkApiClient() as jest.Mocked<BookAVideoLinkApiClient>
     prisonerSearchApiClient = new PrisonerSearchApiClient() as jest.Mocked<PrisonerSearchApiClient>
     manageUsersApiClient = new ManageUsersApiClient() as jest.Mocked<ManageUsersApiClient>
+    officialVisitsService = new OfficialVisitsService(null) as jest.Mocked<OfficialVisitsService>
     scheduleService = new ScheduleService(
       appointmentService,
       referenceDataService,
@@ -50,6 +57,7 @@ describe('Schedule service', () => {
       bookAVideoLinkApiClient,
       prisonerSearchApiClient,
       manageUsersApiClient,
+      officialVisitsService,
     )
 
     appointments = [
@@ -289,6 +297,29 @@ describe('Schedule service', () => {
       },
     ] as BvlsAppointment[]
 
+    officialVisits = [
+      {
+        officialVisitId: 1,
+        visitStatus: 'SCHEDULED',
+        visitStatusDescription: 'Scheduled',
+        visitTypeCode: 'VIDEO',
+        visitTypeDescription: 'Video visit',
+        visitDate: '2024-12-12',
+        startTime: '10:00',
+        endTime: '11:00',
+        dpsLocationId: 'aaaa-bbbb-9f9f9f9f-9f9f9f9f',
+        locationDescription: 'Legal visits ward',
+        visitSlotId: 1,
+        staffNotes: 'Legal representation details',
+        prisonerNotes: 'Please arrive 10 minutes early',
+        createdBy: 'Fred Bloggs',
+        createdTime: '2024-12-12 14:45',
+        prisoner: {
+          prisonerNumber: 'ABC123',
+        },
+      },
+    ] as OfficialVisit[]
+
     prisoners = [
       {
         prisonerNumber: 'ABC123',
@@ -308,9 +339,7 @@ describe('Schedule service', () => {
       },
     ] as Prisoner[]
 
-    appointmentService.getVideoLinkAppointments.mockResolvedValue(appointments)
     referenceDataService.getCellsByWing.mockResolvedValue([{ fullLocationPath: 'A', cells: ['A-001'] }] as CellsByWing)
-    bookAVideoLinkApiClient.getVideoLinkAppointments.mockResolvedValue(bvlsAppointments)
     prisonerSearchApiClient.getByPrisonerNumbers.mockResolvedValue(prisoners)
     nomisMappingApiClient.getLocationMappingsByNomisIds.mockResolvedValue([
       { nomisLocationId: 1, dpsLocationId: 'abc-123' },
@@ -326,7 +355,13 @@ describe('Schedule service', () => {
     )
   })
 
-  describe('getSchedule', () => {
+  describe('getSchedule without official visits', () => {
+    beforeEach(() => {
+      appointmentService.getVideoLinkAppointments.mockResolvedValue(appointments)
+      bookAVideoLinkApiClient.getVideoLinkAppointments.mockResolvedValue(bvlsAppointments)
+      officialVisitsService.getOfficialVisits.mockResolvedValue(officialVisits)
+    })
+
     it('builds a daily schedule', async () => {
       const date = new Date('2024-12-12')
       const result = await scheduleService.getSchedule('MDI', date, undefined, 'ACTIVE', user)
@@ -1975,6 +2010,69 @@ describe('Schedule service', () => {
       expect(expectedAppointments[0]).toMatchObject({ tags: ['CHECK_AVAILABILITY'] })
       expect(expectedAppointments[1]).toMatchObject({ tags: [] })
       expect(expectedAppointments[2]).toMatchObject({ tags: [] })
+    })
+  })
+
+  describe('getSchedule with official visits', () => {
+    beforeEach(() => {
+      appointmentService.getVideoLinkAppointments.mockResolvedValue([])
+      bookAVideoLinkApiClient.getVideoLinkAppointments.mockResolvedValue([])
+      officialVisitsService.getOfficialVisits.mockResolvedValue(officialVisits)
+    })
+
+    it('builds a daily schedule with official visit', async () => {
+      config.featureToggles.includeOfficialVisits = true
+      const date = new Date('2024-12-12')
+      const result = await scheduleService.getSchedule('MDI', date, undefined, 'ACTIVE', user)
+
+      expect(result).toEqual({
+        appointmentGroups: [
+          [
+            {
+              appointmentId: 1,
+              appointmentLocationDescription: 'Legal visits ward',
+              appointmentLocationId: 'aaaa-bbbb-9f9f9f9f-9f9f9f9f',
+              appointmentSubtypeDescription: undefined,
+              appointmentTypeCode: 'VIDEO',
+              appointmentTypeDescription: 'Official Visit - Video',
+              cancelledBy: undefined,
+              cancelledTime: undefined,
+              endTime: '11:00',
+              externalAgencyCode: undefined,
+              externalAgencyDescription: undefined,
+              hmctsNumber: undefined,
+              lastUpdatedOrCreated: '2024-12-12 14:45',
+              notesForPrisoner: undefined,
+              notesForStaff: undefined,
+              prisoner: {
+                cellLocation: 'A-001',
+                firstName: 'Joe',
+                hasAlerts: false,
+                inPrison: true,
+                lastName: 'Bloggs',
+                prisonerNumber: 'ABC123',
+              },
+              probationOfficerName: undefined,
+              startTime: '10:00',
+              status: 'ACTIVE',
+              tags: [],
+              videoBookingId: undefined,
+              videoLink: undefined,
+              videoLinkRequired: undefined,
+              viewAppointmentLink: undefined,
+            },
+          ],
+        ],
+        appointmentsListed: 1,
+        numberOfPrisoners: 1,
+        cancelledAppointments: 0,
+        missingVideoLinks: 0,
+      })
+
+      expect(appointmentService.getVideoLinkAppointments).toHaveBeenLastCalledWith('MDI', date, undefined, user)
+      expect(bookAVideoLinkApiClient.getVideoLinkAppointments).toHaveBeenLastCalledWith('MDI', date, user)
+      expect(prisonerSearchApiClient.getByPrisonerNumbers).toHaveBeenLastCalledWith(['ABC123'], user)
+      expect(nomisMappingApiClient.getLocationMappingsByNomisIds).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/server/services/scheduleService.ts
+++ b/server/services/scheduleService.ts
@@ -22,6 +22,9 @@ import ManageUsersApiClient from '../data/manageUsersApiClient'
 import { ScheduleFilters } from '../routes/journeys/dailySchedule/journey'
 import ReferenceDataService, { CellsByWing } from './referenceDataService'
 import { LocationMapping } from '../@types/nomisMappingApi/types'
+import OfficialVisitsService from './officialVisitsService'
+import config from '../config'
+import { OfficialVisit } from '../@types/officialVisitsApi/types'
 
 const RELEVANT_ALERTS = {
   ACCT_OPEN: 'HA',
@@ -82,6 +85,7 @@ export default class ScheduleService {
     private readonly bookAVideoLinkApiClient: BookAVideoLinkApiClient,
     private readonly prisonerSearchApiClient: PrisonerSearchApiClient,
     private readonly manageUsersApiClient: ManageUsersApiClient,
+    private readonly officialVisitsService: OfficialVisitsService,
   ) {}
 
   public async getSchedule(
@@ -91,12 +95,20 @@ export default class ScheduleService {
     showStatus: 'ACTIVE' | 'CANCELLED',
     user: Express.User,
   ): Promise<DailySchedule> {
-    const [scheduledAppointments, bvlsAppointments] = await Promise.all([
+    const [scheduledAppointments, bvlsAppointments, officialVisits] = await Promise.all([
       this.appointmentService.getVideoLinkAppointments(prisonId, date, filters?.period, user),
       this.bookAVideoLinkApiClient.getVideoLinkAppointments(prisonId, date, user),
+      config.featureToggles.includeOfficialVisits
+        ? this.officialVisitsService.getOfficialVisits(prisonId, date, user)
+        : ([] as OfficialVisit[]),
     ])
 
-    const prisonerNumbers = _.uniq(scheduledAppointments.map(appointment => appointment.offenderNo))
+    const prisonerNumbers = _.uniq(
+      scheduledAppointments
+        .map(appointment => appointment.offenderNo)
+        .concat(officialVisits.map(ov => ov.prisoner.prisonerNumber)),
+    )
+
     const [prisoners, cellsByWing] = await Promise.all([
       this.prisonerSearchApiClient.getByPrisonerNumbers(prisonerNumbers, user),
       this.referenceDataService.getCellsByWing(prisonId, user),
@@ -118,7 +130,8 @@ export default class ScheduleService {
             appointment.dpsLocationId ||
             nomisLocationIdMappings.find(m => m.nomisLocationId === appointment.locationId)?.dpsLocationId,
         }))
-        .map(appointment => this.createScheduleItem(appointment, bvlsAppointments, prisoners, user)),
+        .map(appointment => this.createScheduleItem(appointment, bvlsAppointments, prisoners, user))
+        .concat(officialVisits.map(ov => this.createScheduleItemFromOfficialVisit(ov, prisoners, user))),
     )
 
     const filteredItems = scheduleItems
@@ -224,8 +237,60 @@ export default class ScheduleService {
     }
   }
 
+  private async createScheduleItemFromOfficialVisit(
+    officialVisit: OfficialVisit,
+    prisoners: Prisoner[],
+    user: Express.User,
+  ): Promise<ScheduleItem> {
+    const { createdTime } = officialVisit
+    const { updatedTime } = officialVisit
+
+    return {
+      prisoner: this.getPrisonerFromOfficialVisit(officialVisit, prisoners, user),
+      appointmentId: officialVisit.officialVisitId,
+      status: officialVisit.visitStatus === 'CANCELLED' ? 'CANCELLED' : 'ACTIVE',
+      startTime: officialVisit.startTime,
+      endTime: officialVisit.endTime,
+      appointmentTypeCode: officialVisit.visitTypeCode,
+      appointmentTypeDescription: 'Official Visit - Video',
+      appointmentLocationId: officialVisit.dpsLocationId,
+      appointmentLocationDescription: officialVisit.locationDescription,
+      videoBookingId: undefined,
+      videoLinkRequired: undefined,
+      videoLink: undefined,
+      appointmentSubtypeDescription: undefined,
+      externalAgencyCode: undefined,
+      externalAgencyDescription: undefined,
+      tags: [],
+      viewAppointmentLink: undefined,
+      cancelledTime: officialVisit.visitStatus === 'CANCELLED' ? officialVisit.updatedTime : undefined,
+      cancelledBy:
+        officialVisit.visitStatus === 'CANCELLED'
+          ? await this.getCancelledByFromOfficialVisit(officialVisit, user)
+          : undefined,
+      lastUpdatedOrCreated: updatedTime || createdTime,
+      hmctsNumber: undefined,
+      notesForStaff: undefined,
+      notesForPrisoner: undefined,
+      probationOfficerName: undefined,
+    }
+  }
+
   private getPrisoner(scheduledAppointment: Appointment, prisoners: Prisoner[], user: Express.User) {
     const prisoner = prisoners.find(p => p.prisonerNumber === scheduledAppointment.offenderNo)
+
+    return {
+      prisonerNumber: prisoner.prisonerNumber,
+      firstName: prisoner.firstName,
+      lastName: prisoner.lastName,
+      cellLocation: prisoner.prisonId === user.activeCaseLoadId ? prisoner.cellLocation : 'Out of prison',
+      inPrison: prisoner.prisonId === user.activeCaseLoadId,
+      hasAlerts: prisoner.alerts.filter(a => Object.values(RELEVANT_ALERTS).includes(a.alertCode)).length > 0,
+    }
+  }
+
+  private getPrisonerFromOfficialVisit(officialVisit: OfficialVisit, prisoners: Prisoner[], user: Express.User) {
+    const prisoner = prisoners.find(p => p.prisonerNumber === officialVisit.prisoner.prisonerNumber)
 
     return {
       prisonerNumber: prisoner.prisonerNumber,
@@ -270,6 +335,22 @@ export default class ScheduleService {
 
       if (cancelledByUser) {
         return bvlsAppointment && cancelledByUser.authSource === 'auth' ? 'External user' : cancelledByUser.name
+      }
+    }
+    return undefined
+  }
+
+  private async getCancelledByFromOfficialVisit(officialVisit: OfficialVisit, user: Express.User) {
+    const cancelledBy = officialVisit.updatedBy
+    if (cancelledBy) {
+      const cancelledByUser = await this.manageUsersApiClient.getUserByUsername(cancelledBy, user).catch(err => {
+        if (err.status !== 404) {
+          throw err
+        }
+      })
+
+      if (cancelledByUser) {
+        return cancelledByUser.name
       }
     }
     return undefined

--- a/server/views/pages/dailySchedule/dailySchedule.njk
+++ b/server/views/pages/dailySchedule/dailySchedule.njk
@@ -172,7 +172,7 @@
                                     <a class="govuk-link govuk-link--no-visited-state" href="' + scheduleItem.viewAppointmentLink + '" rel="noreferrer noopener" target="_blank">
                                         View' + (' or edit' if isFutureDay or (isToday and not (scheduleItem.startTime | isBeforeNow))) + '<span class="govuk-visually-hidden">(opens in new tab)</span>
                                     </a>
-                                  ' if loop.index == 1,
+                                  ' if scheduleItem.viewAppointmentLink and loop.index == 1,
                             classes: classes
                         }
                     ]), rows) %}


### PR DESCRIPTION
First initial cut of including official visits in the daily schedule.  Official visits are only viewable in dev.  The feature is turned off in preprod and prod.

- Links to view/edit not yet supported.
- Filtering is not yet supported.
- Movement slips not yet supported.
- CSV extract not yet supported.

<img width="3774" height="1878" alt="image" src="https://github.com/user-attachments/assets/b3dd1fe4-4652-40bf-ae3d-d1679b65dbb5" />
