### PR TITLE
BAVL-1352 add support for inclusion of official visits in the filter.

### DIFF
--- a/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
@@ -66,8 +66,8 @@ describe('GET', () => {
         })
 
         expect(prisonService.isAppointmentsRolledOutAt).toHaveBeenLastCalledWith('MDI', user)
-        expect(referenceDataService.getAppointmentCategories).toHaveBeenLastCalledWith(user)
-        expect(referenceDataService.getAppointmentLocations).toHaveBeenLastCalledWith('MDI', user)
+        expect(referenceDataService.getVideoEventTypes).toHaveBeenLastCalledWith(user)
+        expect(referenceDataService.getVideoLocations).toHaveBeenLastCalledWith('MDI', user)
         expect(referenceDataService.getCourtsAndProbationTeams).toHaveBeenLastCalledWith(user)
         expect(referenceDataService.getCellsByWing).toHaveBeenLastCalledWith('MDI', user)
         expect(scheduleService.getSchedule).toHaveBeenLastCalledWith('MDI', startOfToday(), filters, 'ACTIVE', user)
@@ -269,7 +269,7 @@ describe('GET - with pick-up times present', () => {
     referenceDataService.getAppointmentCategories.mockResolvedValue([
       { code: 'VLB', description: 'Video link - court hearing' },
     ])
-    referenceDataService.getAppointmentLocations.mockResolvedValue([{ id: 'test' } as Location])
+    referenceDataService.getVideoLocations.mockResolvedValue([{ id: 'test' } as Location])
     referenceDataService.getCourtsAndProbationTeams.mockResolvedValue([
       { courtId: 1, code: 'MANCM', description: 'Manchester Magistrates', enabled: true },
     ])
@@ -388,5 +388,15 @@ describe('POST', () => {
           caseLoadId: 'MDI',
         }),
       )
+  })
+
+  it('should clear the filter in session', async () => {
+    // Filter is defaulted in the setup at the top of the file
+    return request(app)
+      .post('/')
+      .send({})
+      .expect(302)
+      .expect('location', `/`)
+      .then(() => expectJourneySession(app, 'scheduleFilters', undefined))
   })
 })

--- a/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.ts
+++ b/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.ts
@@ -56,8 +56,8 @@ export default class DailyScheduleHandler implements PageHandler {
     const [appointmentsRolledOut, appointmentTypes, appointmentLocations, courtsAndProbationTeams, wings, schedule] =
       await Promise.all([
         this.prisonService.isAppointmentsRolledOutAt(user.activeCaseLoadId, user),
-        this.referenceDataService.getAppointmentCategories(user),
-        this.referenceDataService.getAppointmentLocations(user.activeCaseLoadId, user),
+        this.referenceDataService.getVideoEventTypes(user),
+        this.referenceDataService.getVideoLocations(user.activeCaseLoadId, user),
         this.referenceDataService.getCourtsAndProbationTeams(user),
         this.referenceDataService.getCellsByWing(user.activeCaseLoadId, user),
         this.scheduleService.getSchedule(
@@ -98,7 +98,10 @@ export default class DailyScheduleHandler implements PageHandler {
       wing || appointmentType || period || appointmentLocation || courtOrProbationTeam
         ? { wing, appointmentType, period, appointmentLocation, courtOrProbationTeam }
         : undefined
-    req.session.journey.scheduleFilters.caseLoadId = res.locals.user.activeCaseLoadId ?? undefined
+
+    if (req.session.journey.scheduleFilters) {
+      req.session.journey.scheduleFilters.caseLoadId = res.locals.user.activeCaseLoadId ?? undefined
+    }
 
     res.redirect(req.get('Referrer') || '/')
   }

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -5,6 +5,7 @@ import { Location, ResidentialHierarchy } from '../@types/locationsInsidePrisonA
 import BookAVideoLinkApiClient from '../data/bookAVideoLinkApiClient'
 import ActivitiesAndAppointmentsApiClient from '../data/activitiesAndAppointmentsApiClient'
 import { Court, ProbationTeam } from '../@types/bookAVideoLinkApi/types'
+import config from '../config'
 
 jest.mock('../data/locationsInsidePrisonApiClient')
 jest.mock('../data/activitiesAndAppointmentsApiClient')
@@ -31,11 +32,11 @@ describe('Reference data service', () => {
     )
   })
 
-  describe('getAppointmentLocations', () => {
+  describe('getVideoLocations', () => {
     it('Retrieves the location by its nomis ID', async () => {
       locationsInsidePrisonApiClient.getAppointmentLocations.mockResolvedValue([{ id: 'abc-123' } as Location])
 
-      const result = await referenceDataService.getAppointmentLocations('MDI', user)
+      const result = await referenceDataService.getVideoLocations('MDI', user)
 
       expect(result).toEqual([{ id: 'abc-123' }])
       expect(locationsInsidePrisonApiClient.getAppointmentLocations).toHaveBeenCalledWith('MDI', user)
@@ -59,6 +60,43 @@ describe('Reference data service', () => {
         { code: 'VLOO', description: 'Video Link - Official Other' },
       ])
       expect(activitiesAndAppointmentsApiClient.getAppointmentCategories).toHaveBeenCalledWith(user)
+    })
+  })
+
+  describe('getVideoEventTypes', () => {
+    it('Fetches the video event types from A&A', async () => {
+      activitiesAndAppointmentsApiClient.getAppointmentCategories.mockResolvedValue([
+        { code: 'CHAP', description: 'Chaplaincy' },
+        { code: 'VLB', description: 'Video Link - Court Hearing' },
+        { code: 'VLPM', description: 'Video Link - Probation Meeting' },
+        { code: 'VLOO', description: 'Video Link - Official Other' },
+      ])
+
+      const result = await referenceDataService.getVideoEventTypes(user)
+
+      expect(result).toEqual([
+        { code: 'VLB', description: 'Video Link - Court Hearing' },
+        { code: 'VLPM', description: 'Video Link - Probation Meeting' },
+        { code: 'VLOO', description: 'Video Link - Official Other' },
+      ])
+      expect(activitiesAndAppointmentsApiClient.getAppointmentCategories).toHaveBeenCalledWith(user)
+    })
+
+    it('Fetches the video event types from service', async () => {
+      config.featureToggles.includeOfficialVisits = true
+
+      const result = await referenceDataService.getVideoEventTypes(user)
+
+      expect(result).toEqual([
+        { code: 'VLAP', description: 'Video Link - Another Prison' },
+        { code: 'VLB', description: 'Video Link - Court Hearing' },
+        { code: 'VLLA', description: 'Video Link - Legal Appointment' },
+        { code: 'VLOO', description: 'Video Link - Official Other' },
+        { code: 'VLOV', description: 'Video Link - Official Visit' },
+        { code: 'VLPA', description: 'Video Link - Parole Hearing' },
+        { code: 'VLPM', description: 'Video Link - Probation Meeting' },
+      ])
+      expect(activitiesAndAppointmentsApiClient.getAppointmentCategories).not.toHaveBeenCalledWith(user)
     })
   })
 

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -2,12 +2,34 @@ import LocationsInsidePrisonApiClient from '../data/locationsInsidePrisonApiClie
 import BookAVideoLinkApiClient from '../data/bookAVideoLinkApiClient'
 import ActivitiesAndAppointmentsApiClient from '../data/activitiesAndAppointmentsApiClient'
 import { ResidentialHierarchy } from '../@types/locationsInsidePrisonApi/types'
+import config from '../config'
 
 export type CellsByWing = {
   fullLocationPath: string
   localName: string
   cells: string[]
 }[]
+
+export type VideoEventType = {
+  code: string
+  description: string
+}
+
+const APPOINTMENT_TYPES = [
+  { code: 'VLAP', description: 'Video Link - Another Prison' },
+  { code: 'VLLA', description: 'Video Link - Legal Appointment' },
+  { code: 'VLOO', description: 'Video Link - Official Other' },
+  { code: 'VLPA', description: 'Video Link - Parole Hearing' },
+] as VideoEventType[]
+
+const BVLS_TYPES = [
+  { code: 'VLB', description: 'Video Link - Court Hearing' },
+  { code: 'VLPM', description: 'Video Link - Probation Meeting' },
+] as VideoEventType[]
+
+export const OFFICIAL_VISIT_TYPE = { code: 'VLOV', description: 'Video Link - Official Visit' } as VideoEventType
+
+export const VIDEO_EVENT_TYPES = [...APPOINTMENT_TYPES, ...BVLS_TYPES, OFFICIAL_VISIT_TYPE] as VideoEventType[]
 
 export default class ReferenceDataService {
   constructor(
@@ -16,8 +38,14 @@ export default class ReferenceDataService {
     private readonly bookAVideoLinkApiClient: BookAVideoLinkApiClient,
   ) {}
 
-  public async getAppointmentLocations(prisonId: string, user: Express.User) {
+  public async getVideoLocations(prisonId: string, user: Express.User) {
     return this.locationsInsidePrisonApiClient.getAppointmentLocations(prisonId, user)
+  }
+
+  public async getVideoEventTypes(user: Express.User) {
+    return config.featureToggles.includeOfficialVisits
+      ? VIDEO_EVENT_TYPES.sort((a, b) => a.description.localeCompare(b.description))
+      : this.getAppointmentCategories(user)
   }
 
   public async getAppointmentCategories(user: Express.User) {

--- a/server/services/scheduleService.test.ts
+++ b/server/services/scheduleService.test.ts
@@ -2033,7 +2033,7 @@ describe('Schedule service', () => {
               appointmentLocationDescription: 'Legal visits ward',
               appointmentLocationId: 'aaaa-bbbb-9f9f9f9f-9f9f9f9f',
               appointmentSubtypeDescription: undefined,
-              appointmentTypeCode: 'VIDEO',
+              appointmentTypeCode: 'VLOV',
               appointmentTypeDescription: 'Official Visit - Video',
               cancelledBy: undefined,
               cancelledTime: undefined,

--- a/server/services/scheduleService.ts
+++ b/server/services/scheduleService.ts
@@ -20,7 +20,7 @@ import { parseDate } from '../utils/utils'
 import NomisMappingApiClient from '../data/nomisMappingApiClient'
 import ManageUsersApiClient from '../data/manageUsersApiClient'
 import { ScheduleFilters } from '../routes/journeys/dailySchedule/journey'
-import ReferenceDataService, { CellsByWing } from './referenceDataService'
+import ReferenceDataService, { CellsByWing, OFFICIAL_VISIT_TYPE } from './referenceDataService'
 import { LocationMapping } from '../@types/nomisMappingApi/types'
 import OfficialVisitsService from './officialVisitsService'
 import config from '../config'
@@ -251,7 +251,7 @@ export default class ScheduleService {
       status: officialVisit.visitStatus === 'CANCELLED' ? 'CANCELLED' : 'ACTIVE',
       startTime: officialVisit.startTime,
       endTime: officialVisit.endTime,
-      appointmentTypeCode: officialVisit.visitTypeCode,
+      appointmentTypeCode: OFFICIAL_VISIT_TYPE.code,
       appointmentTypeDescription: 'Official Visit - Video',
       appointmentLocationId: officialVisit.dpsLocationId,
       appointmentLocationDescription: officialVisit.locationDescription,

--- a/server/testutils/mocks.ts
+++ b/server/testutils/mocks.ts
@@ -16,7 +16,7 @@ export const mockOfficialVisit = {
   prisonDescription: 'Moorland (HMP & YOI)',
   visitStatus: 'SCHEDULED',
   visitStatusDescription: 'Completed',
-  visitTypeCode: 'TELEPHONE',
+  visitTypeCode: 'VIDEO',
   visitTypeDescription: 'Telephone',
   visitDate: '2022-12-23',
   startTime: '10:00',


### PR DESCRIPTION
These changes now means official visits can be filtered in the filter function on the main daily schedule page.

Screenshots below:

<img width="3970" height="5150" alt="Screenshot 2026-06-04 at 12-37-15 Video link daily schedule Risley (HMP) Video Conference Schedule MoJ" src="https://github.com/user-attachments/assets/7eee986f-dac7-415f-9d2c-d5b6341a341d" />

<img width="3970" height="4282" alt="Screenshot 2026-06-04 at 12-38-07 Video link daily schedule Risley (HMP) Video Conference Schedule MoJ" src="https://github.com/user-attachments/assets/6599d070-beab-47ab-84aa-d09bf1256965" />

<img width="3970" height="4686" alt="Screenshot 2026-06-04 at 12-39-11 Video link daily schedule Risley (HMP) Video Conference Schedule MoJ" src="https://github.com/user-attachments/assets/1d1933ce-e5d5-4ada-b3f7-317a9c0d3028" />
