### PR TITLE
BAVL-1353 official visit movment slip integration with the Daily Schedule.

### DIFF
--- a/integration_tests/mockApis/officialVisitsApi.ts
+++ b/integration_tests/mockApis/officialVisitsApi.ts
@@ -84,25 +84,4 @@ export default {
         },
       },
     }),
-  stubGetNoOfficialVisits: (): SuperAgentRequest =>
-    stubFor({
-      request: {
-        method: 'POST',
-        urlPattern: '/official-visits-api/official-visit/prison/MDI/find-by-criteria\\?page=0&size=200.*',
-        bodyPatterns: [
-          {
-            equalToJson: {
-              startDate: formatDate(today, 'yyyy-MM-dd'),
-              endDate: formatDate(today, 'yyyy-MM-dd'),
-              visitTypes: ['VIDEO'],
-            },
-          },
-        ],
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: { content: [] },
-      },
-    }),
 }

--- a/integration_tests/pages/movementSlipsPage.ts
+++ b/integration_tests/pages/movementSlipsPage.ts
@@ -33,6 +33,8 @@ export default class MovementSlipsPage extends AbstractPage {
 
   legalAppointment = (slipNumber: number) => this.getByDataQa('legal-appointment', slipNumber)
 
+  officialVisit = (slipNumber: number) => this.getByDataQa('official-visit', slipNumber)
+
   pickUpTime = (slipNumber: number) => this.getByDataQa('pick-up-time', slipNumber)
 
   location = (slipNumber: number) => this.getByDataQa('location', slipNumber)

--- a/integration_tests/specs/movementSlips.spec.ts
+++ b/integration_tests/specs/movementSlips.spec.ts
@@ -10,6 +10,7 @@ import prisonerSearchApi from '../mockApis/prisonerSearchApi'
 import MovementSlipsPage from '../pages/movementSlipsPage'
 import { formatDate } from '../../server/utils/utils'
 import officialVisitsApi from '../mockApis/officialVisitsApi'
+import manageUsersApi from '../mockApis/manageUsersApi'
 
 const today = format(new Date(), 'yyyy-MM-dd')
 
@@ -25,8 +26,8 @@ test.describe('Movement slips', () => {
     await componentsApi.stubComponents()
     await locationsInsidePrisonApi.stubGetAppointmentLocations()
     await locationsInsidePrisonApi.stubGetResidentialHierarchy()
-    // Temporary until we have the done the movement slip work for official visits
-    await officialVisitsApi.stubGetNoOfficialVisits()
+    await manageUsersApi.stubUser()
+    await officialVisitsApi.stubGetOfficialVisits()
     await prisonerSearchApi.stubGetPrisoners()
   })
 
@@ -41,6 +42,7 @@ test.describe('Movement slips', () => {
     await expect(movementSlipsPage.prisoner(1)).toHaveText('John Smith, G9566GQ. Location: MDI-1-1-001')
     await expect(movementSlipsPage.prisoner(2)).toHaveText('Damire Stoneheart, W4356WE. Location: MDI-3-4-001')
     await expect(movementSlipsPage.prisoner(3)).toHaveText('Billy Kid, B8965HE. Location: MDI-5-4-001')
+    await expect(movementSlipsPage.prisoner(4)).toHaveText('Jane Doe, Z5461FA. Location: MDI-6-4-001')
   })
 
   test('User can view movement slips with pick-up time 10 minutes before', async ({ page }) => {
@@ -80,6 +82,16 @@ test.describe('Movement slips', () => {
     await expect(movementSlipsPage.legalAppointment(3)).toHaveText('06:00 to 07:00')
     await expect(movementSlipsPage.location(3)).toHaveText('E Wing Video Link')
     await expect(movementSlipsPage.notes(3)).toHaveText('VLLA notes for prisoner B8965HE')
+
+    await expect(movementSlipsPage.slipHeader(4)).toHaveText(
+      'Moorland (HMP) Video appointment movement authorisation slip',
+    )
+    await expect(movementSlipsPage.prisoner(4)).toHaveText('Jane Doe, Z5461FA. Location: MDI-6-4-001')
+    await expect(movementSlipsPage.date(4)).toHaveText(formatDate(today) as string)
+    await expect(movementSlipsPage.pickUpTime(4)).toHaveText('09:50')
+    await expect(movementSlipsPage.officialVisit(4)).toHaveText('10:00 to 11:00')
+    await expect(movementSlipsPage.location(4)).toHaveText('Legal visits ward')
+    await expect(movementSlipsPage.notes(4)).not.toBeVisible()
   })
 
   test('User can view movement slips with pick-up time 20 minutes before', async ({ page }) => {
@@ -119,6 +131,16 @@ test.describe('Movement slips', () => {
     await expect(movementSlipsPage.legalAppointment(3)).toHaveText('06:00 to 07:00')
     await expect(movementSlipsPage.location(3)).toHaveText('E Wing Video Link')
     await expect(movementSlipsPage.notes(3)).toHaveText('VLLA notes for prisoner B8965HE')
+
+    await expect(movementSlipsPage.slipHeader(4)).toHaveText(
+      'Moorland (HMP) Video appointment movement authorisation slip',
+    )
+    await expect(movementSlipsPage.prisoner(4)).toHaveText('Jane Doe, Z5461FA. Location: MDI-6-4-001')
+    await expect(movementSlipsPage.date(4)).toHaveText(formatDate(today) as string)
+    await expect(movementSlipsPage.pickUpTime(4)).toHaveText('09:40')
+    await expect(movementSlipsPage.officialVisit(4)).toHaveText('10:00 to 11:00')
+    await expect(movementSlipsPage.location(4)).toHaveText('Legal visits ward')
+    await expect(movementSlipsPage.notes(4)).not.toBeVisible()
   })
 
   test('User can view movement slips with no pick-up time', async ({ page }) => {

--- a/server/routes/journeys/dailySchedule/handlers/movementSlips.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/movementSlips.test.ts
@@ -429,6 +429,71 @@ describe('GET', () => {
       })
   })
 
+  it('should render an official visit movement slip', () => {
+    scheduleService.getSchedule.mockResolvedValue({
+      appointmentsListed: 1,
+      numberOfPrisoners: 1,
+      cancelledAppointments: 0,
+      missingVideoLinks: 0,
+      appointmentGroups: [
+        [
+          {
+            appointmentId: 1,
+            appointmentLocationDescription: 'Legal visits ward',
+            appointmentLocationId: 'aaaa-bbbb-9f9f9f9f-9f9f9f9f',
+            appointmentSubtypeDescription: undefined,
+            appointmentTypeCode: 'VLOV',
+            appointmentTypeDescription: 'Official Visit - Video',
+            cancelledBy: undefined,
+            cancelledTime: undefined,
+            endTime: '11:00',
+            externalAgencyCode: undefined,
+            externalAgencyDescription: undefined,
+            hmctsNumber: undefined,
+            lastUpdatedOrCreated: '2024-12-12 14:45',
+            notesForPrisoner: 'prisoner notes',
+            notesForStaff: 'staff notes',
+            prisoner: {
+              cellLocation: 'A-001',
+              firstName: 'Joe',
+              hasAlerts: false,
+              inPrison: true,
+              lastName: 'Bloggs',
+              prisonerNumber: 'JOE123',
+            },
+            probationOfficerName: undefined,
+            startTime: '10:00',
+            status: 'ACTIVE',
+            tags: [],
+            videoBookingId: undefined,
+            videoLink: undefined,
+            videoLinkRequired: undefined,
+            viewAppointmentLink: 'http://localhost:3000/view/visit/1',
+          },
+        ],
+      ],
+    })
+
+    return request(app)
+      .get('/movement-slips?date=2055-07-16')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = load(res.text)
+
+        expect(getByClass($, 'movement-slip-header').text().trim()).toEqual(
+          'Moorland (HMP) Video appointment movement authorisation slip',
+        )
+        expect(getByDataQa($, 'date-1').text()).toEqual('16 July 2055')
+        expect(getByDataQa($, 'prisoner-name-and-number-1').text().trim()).toEqual(
+          'Joe Bloggs, JOE123. Location: A-001',
+        )
+        expect(getByDataQa($, 'official-visit-1').text().trim()).toEqual('10:00 to 11:00')
+        expect(getByDataQa($, 'pick-up-time-1').text().trim()).toEqual('09:30')
+        expect(getByDataQa($, 'location-1').text().trim()).toEqual('Legal visits ward')
+        expect(getByDataQa($, 'notes-1').text().trim()).toContain('')
+      })
+  })
+
   it(`should render movements slip page for today`, () => {
     scheduleService.getSchedule.mockResolvedValue({
       appointmentsListed: 1,

--- a/server/routes/journeys/dailySchedule/handlers/movementSlips.ts
+++ b/server/routes/journeys/dailySchedule/handlers/movementSlips.ts
@@ -87,6 +87,12 @@ export default class MovementSlipsHandler implements PageHandler {
               endTime: this.getEndTime(group, AppointmentType.OFFICIAL_OTHER),
             }
           : undefined,
+        officialVisit: this.isAppointmentType(AppointmentType.OFFICIAL_VISIT, group)
+          ? {
+              startTime: this.getStartTime(group, AppointmentType.OFFICIAL_VISIT),
+              endTime: this.getEndTime(group, AppointmentType.OFFICIAL_VISIT),
+            }
+          : undefined,
         pickUpTime: prison.pickUpTime ? removeMinutes(group[0].startTime, prison.pickUpTime) : undefined,
         location: this.getLocation(group),
         notes: group[0].notesForPrisoner,
@@ -108,9 +114,6 @@ export default class MovementSlipsHandler implements PageHandler {
 
   private getMeetingType = (group: ScheduleItem[]) =>
     group.find(g => g.appointmentTypeCode === AppointmentType.PROBATION)?.appointmentSubtypeDescription
-
-  private getStartTimeOld = (group: ScheduleItem[], type: string) =>
-    group.find(g => g.appointmentTypeDescription.includes(type))?.startTime
 
   private getStartTime = (group: ScheduleItem[], type: AppointmentType, desc?: string) => {
     if (desc) {
@@ -170,6 +173,12 @@ export default class MovementSlipsHandler implements PageHandler {
       return location
     }
 
+    location = group.find(g => g.appointmentTypeCode === AppointmentType.OFFICIAL_VISIT)?.appointmentLocationDescription
+
+    if (isNotEmpty(location)) {
+      return location
+    }
+
     return undefined
   }
 }
@@ -179,6 +188,7 @@ enum AppointmentType {
   COURT = 'VLB',
   LEGAL = 'VLLA',
   OFFICIAL_OTHER = 'VLOO',
+  OFFICIAL_VISIT = 'VLOV',
   PAROLE = 'VLPA',
   PROBATION = 'VLPM',
 }

--- a/server/views/partials/movementSlip.njk
+++ b/server/views/partials/movementSlip.njk
@@ -48,6 +48,10 @@
                 {{ labelAndValue(slipNum, 'Parole hearing', movementSlip.parole.startTime + ' to ' +  movementSlip.parole.endTime, '', 'movement-slip__summary__row__key--normal') }}
             {% endif %}
 
+            {% if movementSlip.officialVisit %}
+                {{ labelAndValue(slipNum, 'Official visit', movementSlip.officialVisit.startTime + ' to ' +  movementSlip.officialVisit.endTime, '', 'movement-slip__summary__row__key--normal') }}
+            {% endif %}
+
             {% if movementSlip.probation %}
                 {{ labelAndValue(slipNum, 'Probation meeting - ' + movementSlip.probation.meetingType, movementSlip.probation.startTime + ' to ' +  movementSlip.probation.endTime, '', 'movement-slip__summary__row__key--normal') }}
             {% endif %}
@@ -61,8 +65,10 @@
             <img alt='Information' src='/assets/images/icon-information.svg' />
             Be ready on time. No vaping allowed. Refusal to attend will be recorded.
         </div>
-        <h1 class="govuk-heading-s">Notes</h1>
-        <div data-qa='notes-{{ slipNum }}' class="govuk-body-m">{{ movementSlip.notes }}</div>
+        {% if not movementSlip.officialVisit %}
+          <h1 class="govuk-heading-s">Notes</h1>
+          <div data-qa='notes-{{ slipNum }}' class="govuk-body-m">{{ movementSlip.notes }}</div>
+        {% endif %}
         <p class="govuk-body-s movement-slip-footer">Date printed {{ printedAt | formatDate("d MMMM yyyy") }}</p>
     </div>
 


### PR DESCRIPTION
Adding support for printing official visit movement slips in the Daily Schedule.

<img width="4176" height="2010" alt="official-visit-movement-slip" src="https://github.com/user-attachments/assets/bfd3da3f-74db-4394-8bbd-5e44bc24e033" />
