### PR TITLE
BAVL-1354 changes to make sure staff notes are not downloaded for Official Visits.

### DIFF
--- a/integration_tests/pages/homePage.ts
+++ b/integration_tests/pages/homePage.ts
@@ -24,6 +24,8 @@ export default class HomePage extends AbstractPage {
 
   readonly showAllPickUpTimesButton: Locator
 
+  readonly downloadCsv: Locator
+
   private constructor(page: Page) {
     super(page)
     this.header = page.locator('h1', { hasText: 'Video link daily schedule: Moorland (HMP)' })
@@ -37,6 +39,7 @@ export default class HomePage extends AbstractPage {
     this.printAllMovementSlipsLink = page.getByRole('link', { name: 'Print all movement slips' })
     this.viewCancellationsLink = page.getByRole('link', { name: 'View' })
     this.showAllPickUpTimesButton = page.getByRole('button', { name: 'Show all pick-up times' })
+    this.downloadCsv = page.getByRole('button', { name: 'Export as spreadsheet (.csv file)' })
   }
 
   static async verifyOnPage(page: Page): Promise<HomePage> {

--- a/integration_tests/specs/dailySchedule.spec.ts
+++ b/integration_tests/specs/dailySchedule.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 
+import { format } from 'date-fns'
 import { login, resetStubs } from '../testUtils'
 import HomePage from '../pages/homePage'
 import componentsApi from '../mockApis/componentsApi'
@@ -10,6 +11,8 @@ import prisonerSearchApi from '../mockApis/prisonerSearchApi'
 import CancellationsPage from '../pages/cancellationsPage'
 import officialVisitsApi from '../mockApis/officialVisitsApi'
 import manageUsersApi from '../mockApis/manageUsersApi'
+
+const today = format(new Date(), 'yyyy-MM-dd')
 
 test.describe('Daily schedule', () => {
   test.beforeEach(async () => {
@@ -86,5 +89,13 @@ test.describe('Daily schedule', () => {
     await expect(tagLocator.nth(0)).toHaveText('Link missing')
     await expect(tagLocator.nth(1)).toHaveText('Pin protected')
     await expect(tagLocator.nth(2)).toHaveText('Check room')
+  })
+
+  test('User can download a CSV file of the daily schedule for the day', async ({ page }) => {
+    await login(page, { name: 'A TestUser' })
+    const homePage = await HomePage.verifyOnPage(page)
+    const [download] = await Promise.all([page.waitForEvent('download'), homePage.downloadCsv.click()])
+    expect(download).toBeTruthy()
+    expect(download.suggestedFilename()).toBe(`daily-schedule-${today}.csv`)
   })
 })

--- a/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.test.ts
@@ -36,7 +36,8 @@ const expectedCsvNoPickupTimes =
   '\nDoe Jane,HIJ123,C-1-001,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00,,' +
   '\nBat Man,RR9100,R-1-9000,13:00,13:30,Probation Meeting,,X Wing Video Link,,,,Not yet known,' +
   '\nFlintrock Fred,BC5000,B-1-5000,16:00,17:00,Court Hearing,,Z Wing Video Link,,,,,' +
-  '\nLawless Lucy,ZZ5000,X-1-4000,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name,"Probation meeting staff notes with special characters, "" \' À"'
+  '\nLawless Lucy,ZZ5000,X-1-4000,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name,"Probation meeting staff notes with special characters, "" \' À"' +
+  '\nKey Don,ZZ6000,F-1-5000,18:00,19:00,Official Visit - Video,,F Wing,,,,,'
 
 const expectedCsvWithPickupTimes =
   'Prisoner name,Prison number,Cell number,Pick-up time,Appointment start time,Appointment end time,Appointment type,Appointment subtype,Room location,Court or probation team,Video link,Last updated,Probation officer name,Staff notes' +
@@ -46,13 +47,15 @@ const expectedCsvWithPickupTimes =
   '\nDoe Jane,HIJ123,C-1-001,10:30,11:00,12:00,Court Hearing,,C Wing Video Link,,,10 December 2024 at 00:00,,' +
   '\nBat Man,RR9100,R-1-9000,12:30,13:00,13:30,Probation Meeting,,X Wing Video Link,,,,Not yet known,' +
   '\nFlintrock Fred,BC5000,B-1-5000,15:30,16:00,17:00,Court Hearing,,Z Wing Video Link,,,,,' +
-  '\nLawless Lucy,ZZ5000,X-1-4000,15:30,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name,"Probation meeting staff notes with special characters, "" \' À"'
+  '\nLawless Lucy,ZZ5000,X-1-4000,15:30,16:00,17:00,Probation Meeting,,G Wing Video Link,,,,Probation Officer Name,"Probation meeting staff notes with special characters, "" \' À"' +
+  '\nKey Don,ZZ6000,F-1-5000,17:30,18:00,19:00,Official Visit - Video,,F Wing,,,,,'
 
 beforeEach(() => {
   scheduleService.getSchedule.mockResolvedValue({
     appointmentGroups: [
       [
         {
+          appointmentTypeCode: 'VLB',
           prisoner: { firstName: 'John', lastName: 'Smith', prisonerNumber: 'ABC123', cellLocation: 'A-1-001' },
           startTime: '10:45',
           endTime: '11:00',
@@ -64,6 +67,7 @@ beforeEach(() => {
           videoLinkId: 1,
         },
         {
+          appointmentTypeCode: 'VLB',
           prisoner: { firstName: 'John', lastName: 'Smith', prisonerNumber: 'ABC123', cellLocation: 'A-1-001' },
           startTime: '11:00',
           endTime: '12:00',
@@ -78,6 +82,7 @@ beforeEach(() => {
       ],
       [
         {
+          appointmentTypeCode: 'VLB',
           prisoner: { firstName: 'John', lastName: 'Doe', prisonerNumber: 'DEF123', cellLocation: 'B-1-001' },
           startTime: '11:00',
           endTime: '12:00',
@@ -90,6 +95,7 @@ beforeEach(() => {
       ],
       [
         {
+          appointmentTypeCode: 'VLB',
           prisoner: { firstName: 'Jane', lastName: 'Doe', prisonerNumber: 'HIJ123', cellLocation: 'C-1-001' },
           startTime: '11:00',
           endTime: '12:00',
@@ -101,6 +107,7 @@ beforeEach(() => {
       ],
       [
         {
+          appointmentTypeCode: 'VLPM',
           prisoner: { firstName: 'Man', lastName: 'Bat', prisonerNumber: 'RR9100', cellLocation: 'R-1-9000' },
           startTime: '13:00',
           endTime: '13:30',
@@ -113,6 +120,7 @@ beforeEach(() => {
       ],
       [
         {
+          appointmentTypeCode: 'VLB',
           prisoner: { firstName: 'Fred', lastName: 'Flintrock', prisonerNumber: 'BC5000', cellLocation: 'B-1-5000' },
           startTime: '16:00',
           endTime: '17:00',
@@ -124,6 +132,7 @@ beforeEach(() => {
       ],
       [
         {
+          appointmentTypeCode: 'VLPM',
           prisoner: { firstName: 'Lucy', lastName: 'Lawless', prisonerNumber: 'ZZ5000', cellLocation: 'X-1-4000' },
           startTime: '16:00',
           endTime: '17:00',
@@ -133,6 +142,20 @@ beforeEach(() => {
           videoLinkRequired: true,
           probationOfficerName: 'Probation Officer Name',
           notesForStaff: 'Probation meeting staff notes with special characters, " \' À',
+        },
+      ],
+      [
+        {
+          appointmentTypeCode: 'VLOV',
+          prisoner: { firstName: 'Don', lastName: 'Key', prisonerNumber: 'ZZ6000', cellLocation: 'F-1-5000' },
+          startTime: '18:00',
+          endTime: '19:00',
+          appointmentTypeDescription: 'Official Visit - Video',
+          appointmentLocationDescription: 'F Wing',
+          lastUpdatedOrCreated: undefined,
+          videoLinkRequired: true,
+          probationOfficerName: undefined,
+          notesForStaff: 'Official visit staff notes for prisoner Don Key ZZ6000 should not appear in the CSV',
         },
       ],
     ],

--- a/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.ts
+++ b/server/routes/journeys/dailySchedule/handlers/downloadCsvHandler.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../../services/auditService'
 import { PageHandler } from '../../../interfaces/pageHandler'
 import ScheduleService, { DailySchedule, ScheduleItem } from '../../../../services/scheduleService'
 import { convertToTitleCase, formatDate, removeMinutes, toFullCourtLinkPrint } from '../../../../utils/utils'
+import { OFFICIAL_VISIT_TYPE } from '../../../../services/referenceDataService'
 
 export default class DownloadCsvHandler implements PageHandler {
   public PAGE_NAME = Page.DOWNLOAD_DAILY_SCHEDULE
@@ -56,7 +57,7 @@ export default class DownloadCsvHandler implements PageHandler {
           ? formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm")
           : '',
         'Probation officer name': this.probationOfficerNameOrUndefined(item) || '',
-        'Staff notes': item.notesForStaff || '',
+        'Staff notes': this.includeStaffNotesIfNotOfficialVisit(item),
       })),
     )
   }
@@ -79,7 +80,7 @@ export default class DownloadCsvHandler implements PageHandler {
           ? formatDate(item.lastUpdatedOrCreated, "d MMMM yyyy 'at' HH:mm")
           : '',
         'Probation officer name': this.probationOfficerNameOrUndefined(item) || '',
-        'Staff notes': item.notesForStaff || '',
+        'Staff notes': this.includeStaffNotesIfNotOfficialVisit(item),
       })),
     )
   }
@@ -101,5 +102,9 @@ export default class DownloadCsvHandler implements PageHandler {
     return item.appointmentTypeDescription === 'Probation Meeting'
       ? item.probationOfficerName || 'Not yet known'
       : undefined
+  }
+
+  private includeStaffNotesIfNotOfficialVisit = (item: ScheduleItem) => {
+    return item.notesForStaff && item.appointmentTypeCode !== OFFICIAL_VISIT_TYPE.code ? item.notesForStaff : ''
   }
 }


### PR DESCRIPTION
Adding explicit check to the CSV download process to make sure staff notes are not included for Official Visits.

Added a basic integration test for the CSV download, there was no coverage.