### PR TITLE
MAPB-579 Migrate to non-residential service-type locations endpoint

### DIFF
--- a/integration_tests/mockApis/locationsInsidePrisonApi.ts
+++ b/integration_tests/mockApis/locationsInsidePrisonApi.ts
@@ -19,7 +19,7 @@ export default {
       request: {
         method: 'GET',
         urlPattern:
-          '/locations-inside-prison-api/locations/non-residential/prison/MDI/service/APPOINTMENT\\?formatLocalName=true&sortByLocalName=true',
+          '/locations-inside-prison-api/locations/non-residential/prison/MDI/service/APPOINTMENT\\?formatLocalName=true&sortByLocalName=true&filterParents=false',
       },
       response: {
         status: 200,

--- a/integration_tests/mockApis/locationsInsidePrisonApi.ts
+++ b/integration_tests/mockApis/locationsInsidePrisonApi.ts
@@ -19,7 +19,7 @@ export default {
       request: {
         method: 'GET',
         urlPattern:
-          '/locations-inside-prison-api/locations/prison/MDI/non-residential-usage-type/APPOINTMENT\\?formatLocalName=true&sortByLocalName=true',
+          '/locations-inside-prison-api/locations/non-residential/prison/MDI/service/APPOINTMENT\\?formatLocalName=true&sortByLocalName=true',
       },
       response: {
         status: 200,

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -29,7 +29,7 @@ describe('locationsInsidePrisonApiClient', () => {
       const response = { data: 'data' }
 
       fakeLocationsInsidePrisonApiClient
-        .get('/locations/prison/MDI/non-residential-usage-type/APPOINTMENT?formatLocalName=true&sortByLocalName=true')
+        .get('/locations/non-residential/prison/MDI/service/APPOINTMENT?formatLocalName=true&sortByLocalName=true')
         .matchHeader('authorization', `Bearer systemToken`)
         .reply(200, response)
 

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -29,7 +29,9 @@ describe('locationsInsidePrisonApiClient', () => {
       const response = { data: 'data' }
 
       fakeLocationsInsidePrisonApiClient
-        .get('/locations/non-residential/prison/MDI/service/APPOINTMENT?formatLocalName=true&sortByLocalName=true&filterParents=false')
+        .get(
+          '/locations/non-residential/prison/MDI/service/APPOINTMENT?formatLocalName=true&sortByLocalName=true&filterParents=false',
+        )
         .matchHeader('authorization', `Bearer systemToken`)
         .reply(200, response)
 

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -29,7 +29,7 @@ describe('locationsInsidePrisonApiClient', () => {
       const response = { data: 'data' }
 
       fakeLocationsInsidePrisonApiClient
-        .get('/locations/non-residential/prison/MDI/service/APPOINTMENT?formatLocalName=true&sortByLocalName=true')
+        .get('/locations/non-residential/prison/MDI/service/APPOINTMENT?formatLocalName=true&sortByLocalName=true&filterParents=false')
         .matchHeader('authorization', `Bearer systemToken`)
         .reply(200, response)
 

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -11,7 +11,7 @@ export default class LocationsInsidePrisonApiClient extends RestClient {
     return this.get(
       {
         path: `/locations/non-residential/prison/${prisonId}/service/APPOINTMENT`,
-        query: { formatLocalName: true, sortByLocalName: true },
+        query: { formatLocalName: true, sortByLocalName: true, filterParents: false },
       },
       user,
     )

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -10,7 +10,7 @@ export default class LocationsInsidePrisonApiClient extends RestClient {
   getAppointmentLocations(prisonId: string, user: Express.User): Promise<Location[]> {
     return this.get(
       {
-        path: `/locations/prison/${prisonId}/non-residential-usage-type/APPOINTMENT`,
+        path: `/locations/non-residential/prison/${prisonId}/service/APPOINTMENT`,
         query: { formatLocalName: true, sortByLocalName: true },
       },
       user,


### PR DESCRIPTION
## What
Migrate off the deprecated locations-inside-prison-api endpoint `GET /locations/prison/{prisonId}/non-residential-usage-type/{usageType}` to its replacement `GET /locations/non-residential/prison/{prisonId}/service/{serviceType}` (`serviceType=APPOINTMENT`).

## Why
The usage-type endpoint is marked `deprecated: true`. This service was one of three still calling it. The replacement is on the API's main (MAP-2930 / PR #477).

## Notes
- `usageType=APPOINTMENT` maps directly to `serviceType=APPOINTMENT` (per the API's `ServiceType` enum).
- Same auth role (`VIEW_LOCATIONS`), same query params (`formatLocalName`/`sortByLocalName`) and identical `Location` response shape, so no call-site or response-mapping changes were needed.
- Client path, unit test and WireMock/nock stub updated; unit tests pass.