### PR TITLE
BAVL-1359 adding the basic routing for the availablity checker. Will only be available for enabled prisons.

### DIFF
--- a/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
+++ b/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
@@ -57,6 +57,8 @@ generic-service:
     sqs-hmpps-audit-secret:
       AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
       AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
+    feature-toggles:
+      FEATURE_AVAILABILITY_CHECKER_PRISONS: "FEATURE_AVAILABILITY_CHECKER_PRISONS?"
 
   allowlist:
     groups:

--- a/server/config.ts
+++ b/server/config.ts
@@ -196,5 +196,6 @@ export default {
   featureToggles: {
     temporaryBlockingLocations: get('FEATURE_TEMPORARY_BLOCKING_LOCATIONS', false) === 'true',
     includeOfficialVisits: get('FEATURE_INCLUDE_OFFICIAL_VISITS', false) === 'true',
+    availabilityCheckerPrisons: get('FEATURE_AVAILABILITY_CHECKER_PRISONS', null),
   },
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,11 +1,13 @@
 import { Router } from 'express'
 import dailySchedule from './journeys/dailySchedule'
+import availabilityChecker from './journeys/availabilityChecker'
 import { Services } from '../services'
 
 export default function routes(services: Services): Router {
   const router = Router()
 
   router.use('/', dailySchedule(services))
+  router.use('/availability-checker', availabilityChecker(services))
 
   return router
 }

--- a/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.test.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.test.ts
@@ -1,0 +1,90 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import { load } from 'cheerio'
+import { appWithAllRoutes, user } from '../../../testutils/appSetup'
+import AuditService, { Page } from '../../../../services/auditService'
+import { getPageHeader } from '../../../testutils/cheerio'
+import config from '../../../../config'
+
+jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/prisonService')
+jest.mock('../../../../services/scheduleService')
+
+const auditService = new AuditService(null) as jest.Mocked<AuditService>
+
+let app: Express
+
+const risleyUser = {
+  ...user,
+  activeCaseLoadId: 'RSI',
+}
+
+const appSetup = (journeySession = {}) => {
+  app = appWithAllRoutes({
+    services: { auditService },
+    userSupplier: () => risleyUser,
+    journeySessionSupplier: () => journeySession,
+  })
+}
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET', () => {
+  beforeEach(() => {
+    appSetup()
+  })
+
+  it('should render availability checker when Risley prison is enabled', () => {
+    config.featureToggles.availabilityCheckerPrisons = 'RSI'
+
+    return request(app)
+      .get('/availability-checker')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = load(res.text)
+
+        expect(getPageHeader($)).toEqual('The availability checker is currently unavailable')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.AVAILABILTY_CHECKER_PAGE, {
+          who: user.username,
+          correlationId: expect.any(String),
+          details: JSON.stringify({ query: {} }),
+        })
+      })
+  })
+
+  it('should not render availability checker when Risley prison is not enabled', () => {
+    config.featureToggles.availabilityCheckerPrisons = 'MDI'
+
+    return request(app)
+      .get('/availability-checker')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = load(res.text)
+
+        expect(getPageHeader($)).toEqual('Page not found')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.AVAILABILTY_CHECKER_PAGE, {
+          who: user.username,
+          correlationId: expect.any(String),
+          details: JSON.stringify({ query: {} }),
+        })
+      })
+  })
+
+  it('should not render availability checker when no prison is enabled', () => {
+    return request(app)
+      .get('/availability-checker')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = load(res.text)
+
+        expect(getPageHeader($)).toEqual('Page not found')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.AVAILABILTY_CHECKER_PAGE, {
+          who: user.username,
+          correlationId: expect.any(String),
+          details: JSON.stringify({ query: {} }),
+        })
+      })
+  })
+})

--- a/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line max-classes-per-file
+import { Request, Response } from 'express'
+import { Page } from '../../../../services/auditService'
+import { PageHandler } from '../../../interfaces/pageHandler'
+import config from '../../../../config'
+
+class Body {}
+
+export default class AvailabilityCheckerHandler implements PageHandler {
+  public PAGE_NAME = Page.AVAILABILTY_CHECKER_PAGE
+
+  public BODY = Body
+
+  GET = async (req: Request, res: Response) => {
+    const enabledPrisons = config.featureToggles.availabilityCheckerPrisons?.split(',')
+    const { user } = res.locals
+
+    if (enabledPrisons && enabledPrisons.includes(user.activeCaseLoadId)) {
+      res.render('pages/availabilityChecker/availabilityChecker')
+    } else {
+      res.render('pages/error/404')
+    }
+  }
+}

--- a/server/routes/journeys/availabilityChecker/index.ts
+++ b/server/routes/journeys/availabilityChecker/index.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express'
+import { PageHandler } from '../../interfaces/pageHandler'
+import logPageViewMiddleware from '../../../middleware/logPageViewMiddleware'
+import type { Services } from '../../../services'
+import AvailabilityCheckerHandler from './handlers/availabilityCheckerHandler'
+
+export default function Index({ auditService }: Services): Router {
+  const router = Router({ mergeParams: true })
+
+  const get = (path: string, handler: PageHandler) =>
+    router.get(path, logPageViewMiddleware(auditService, handler), handler.GET)
+
+  get('/', new AvailabilityCheckerHandler())
+
+  return router
+}

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -1,6 +1,7 @@
 import HmppsAuditClient, { AuditEvent } from '../data/hmppsAuditClient'
 
 export enum Page {
+  AVAILABILTY_CHECKER_PAGE = 'AVAILABILTY_CHECKER',
   CLEAR_FILTER = 'CLEAR_FILTER',
   DAILY_SCHEDULE_PAGE = 'DAILY_SCHEDULE_PAGE',
   DOWNLOAD_DAILY_SCHEDULE = 'DOWNLOAD_DAILY_SCHEDULE',

--- a/server/views/pages/availabilityChecker/availabilityChecker.njk
+++ b/server/views/pages/availabilityChecker/availabilityChecker.njk
@@ -1,0 +1,19 @@
+{% extends "partials/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set hideBackLink = true %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">The availability checker is currently unavailable</h1>
+            <p class="govuk-body">We apologise for any inconvenience this may cause and thank you for your patience.</p>
+
+            {{ govukButton({
+                text: "Return to HMPPS Digital Services",
+                classes: 'govuk-!-margin-top-6',
+                href: authUrl
+            }) }}
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
This change gets the basic routing in for the availability checker work.

If the feature is enabled for the users caseload then the user will see an information page telling them the feature us under development, otherwise a 404 will be reported.