### PR TITLE
BAVL-1359 adding work day/weekend validation on date input.

### DIFF
--- a/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.test.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.test.ts
@@ -1,12 +1,14 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import { load } from 'cheerio'
+import { startOfDay } from 'date-fns'
 import { appWithAllRoutes, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import RoomAvailabilityService from '../../../../services/roomAvailabilityService'
 import { existsByDataQa, getPageHeader } from '../../../testutils/cheerio'
 import config from '../../../../config'
 import { Prison } from '../../../../@types/bookAVideoLinkApi/types'
+import { expectErrorMessages } from '../../../testutils/expectErrorMessage'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/roomAvailabilityService')
@@ -47,7 +49,7 @@ describe('GET', () => {
   })
 
   it.each([
-    ['AM', '2024-12-10', 'time-8'],
+    ['AM', '2026-07-24', 'time-8'],
     ['PM', '2024-12-11', 'time-13'],
     ['ED', '2024-12-12', 'time-18'],
   ])(
@@ -63,6 +65,13 @@ describe('GET', () => {
 
           expect(getPageHeader($)).toEqual('Video link availability checker: Risley (HMP)')
           expect(existsByDataQa($, time)).toBe(true)
+          expect(roomAvailabilityService.getRoomAvailability).toHaveBeenCalledWith(
+            'RSI',
+            startOfDay(date),
+            startOfDay(date),
+            period,
+            risleyUser,
+          )
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.AVAILABILTY_CHECKER_PAGE, {
             who: user.username,
             correlationId: expect.any(String),
@@ -71,6 +80,34 @@ describe('GET', () => {
         })
     },
   )
+
+  it.each([
+    ['2026-07-25', '2026-07-27'],
+    ['2026-07-26', '2026-07-27'],
+  ])('should render Monday if date falls at the weekend (%s), date (%s)', (weekendDate: string, date: string) => {
+    config.featureToggles.availabilityCheckerPrisons = 'RSI'
+
+    return request(app)
+      .get(`/availability-checker?period=AM&date=${weekendDate}`)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = load(res.text)
+
+        expect(getPageHeader($)).toEqual('Video link availability checker: Risley (HMP)')
+        expect(roomAvailabilityService.getRoomAvailability).toHaveBeenCalledWith(
+          'RSI',
+          startOfDay(date),
+          startOfDay(date),
+          'AM',
+          risleyUser,
+        )
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.AVAILABILTY_CHECKER_PAGE, {
+          who: user.username,
+          correlationId: expect.any(String),
+          details: JSON.stringify({ query: { period: 'AM', date: weekendDate } }),
+        })
+      })
+  })
 
   it('should not render availability checker when Risley prison is not enabled', () => {
     config.featureToggles.availabilityCheckerPrisons = 'MDI'
@@ -82,6 +119,7 @@ describe('GET', () => {
         const $ = load(res.text)
 
         expect(getPageHeader($)).toEqual('Page not found')
+        expect(roomAvailabilityService.getRoomAvailability).not.toHaveBeenCalled()
         expect(auditService.logPageView).toHaveBeenCalledWith(Page.AVAILABILTY_CHECKER_PAGE, {
           who: user.username,
           correlationId: expect.any(String),
@@ -98,6 +136,7 @@ describe('GET', () => {
         const $ = load(res.text)
 
         expect(getPageHeader($)).toEqual('Page not found')
+        expect(roomAvailabilityService.getRoomAvailability).not.toHaveBeenCalled()
         expect(auditService.logPageView).toHaveBeenCalledWith(Page.AVAILABILTY_CHECKER_PAGE, {
           who: user.username,
           correlationId: expect.any(String),
@@ -124,5 +163,73 @@ describe('POST', () => {
       .send({ date, period })
       .expect(302)
       .expect('location', `availability-checker?date=${parsedDate}&period=${period}`)
+  })
+
+  it.each([['25/07/2026'], ['26/07/2026']])('should validate date is a working day', (date: string) => {
+    config.featureToggles.availabilityCheckerPrisons = 'RSI'
+
+    return request(app)
+      .post('/availability-checker')
+      .send({ date, period: 'AM' })
+      .expect(() => {
+        expectErrorMessages([
+          {
+            fieldId: 'date',
+            href: '#date',
+            text: 'Select a working day',
+          },
+        ])
+      })
+  })
+
+  it('should validate date provided', () => {
+    config.featureToggles.availabilityCheckerPrisons = 'RSI'
+
+    return request(app)
+      .post('/availability-checker')
+      .send({ period: 'AM' })
+      .expect(() => {
+        expectErrorMessages([
+          {
+            fieldId: 'date',
+            href: '#date',
+            text: 'Enter a date',
+          },
+        ])
+      })
+  })
+
+  it('should validate date is valid', () => {
+    config.featureToggles.availabilityCheckerPrisons = 'RSI'
+
+    return request(app)
+      .post('/availability-checker')
+      .send({ date: '31/02/2026', period: 'AM' })
+      .expect(() => {
+        expectErrorMessages([
+          {
+            fieldId: 'date',
+            href: '#date',
+            text: 'Enter a valid date',
+          },
+        ])
+      })
+  })
+
+  it('should validate session is provided', () => {
+    config.featureToggles.availabilityCheckerPrisons = 'RSI'
+
+    return request(app)
+      .post('/availability-checker')
+      .send({ date: '03/02/2026' })
+      .expect(() => {
+        expectErrorMessages([
+          {
+            fieldId: 'period',
+            href: '#period',
+            text: 'Select a session',
+          },
+        ])
+      })
   })
 })

--- a/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.ts
@@ -2,7 +2,7 @@
 import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
 import { IsNotEmpty } from 'class-validator'
-import { formatDate, isValid, startOfDay } from 'date-fns'
+import { formatDate, isValid, isWeekend, nextMonday, startOfDay } from 'date-fns'
 import { Page } from '../../../../services/auditService'
 import { PageHandler } from '../../../interfaces/pageHandler'
 import config from '../../../../config'
@@ -10,12 +10,14 @@ import { parseDatePickerDate } from '../../../../utils/utils'
 import IsValidDate from '../../../validators/isValidDate'
 import RoomAvailabilityService from '../../../../services/roomAvailabilityService'
 import { Period } from '../../../../services/appointmentService'
+import IsWeekDay from '../../../validators/isWeekDay'
 
 class Body {
   @Expose()
   @Transform(({ value }) => parseDatePickerDate(value))
   @IsValidDate({ message: 'Enter a valid date' })
   @IsNotEmpty({ message: 'Enter a date' })
+  @IsWeekDay({ message: 'Select a working day' })
   date: Date
 
   @Expose()
@@ -38,13 +40,21 @@ export default class AvailabilityCheckerHandler implements PageHandler {
       const prison = req.middleware!.prison!
       const dateFromQueryParam = new Date(req.query.date?.toString())
       const date = startOfDay(isValid(dateFromQueryParam) ? dateFromQueryParam : new Date())
+      const weekDay = isWeekend(date) ? nextMonday(date) : date
+
       const period: Period = <Period>req.query.period || 'AM'
 
       res.render('pages/availabilityChecker/availabilityChecker', {
         prison,
-        date,
+        date: weekDay,
         period,
-        roomAvailability: await this.roomAvailabilityService.getRoomAvailability(prison.code, date, date, period, user),
+        roomAvailability: await this.roomAvailabilityService.getRoomAvailability(
+          prison.code,
+          weekDay,
+          weekDay,
+          period,
+          user,
+        ),
       })
     } else {
       res.render('pages/error/404')

--- a/server/routes/validators/isWeekDay.ts
+++ b/server/routes/validators/isWeekDay.ts
@@ -1,0 +1,16 @@
+import { registerDecorator, ValidationOptions } from 'class-validator'
+import { isWeekend } from 'date-fns'
+
+export default function IsWeekDay(validationOptions: ValidationOptions) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: 'IsValidDate',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate: dateToValidate => isWeekend(dateToValidate) === false,
+      },
+    })
+  }
+}

--- a/server/views/pages/availabilityChecker/availabilityChecker.njk
+++ b/server/views/pages/availabilityChecker/availabilityChecker.njk
@@ -264,15 +264,15 @@
 
 {% macro roomHtml(room, index) %}
     {% if not room.hourlySlots[index].freeSlots.length %}
-    <div>Booked</div>
+      Booked
     {% else %}
       {% if room.hourlySlots[index].freeSlots.length %}
           {% if room.hourlySlots[index].freeSlots.length == 1 and room.hourlySlots[index].freeSlots[0].durationInMinutes == 60 %}
-              <ul class="govuk-list govuk-list__green govuk-list--spaced">
+              <ul class="govuk-list govuk-list__green">
                   <li>Free</li>
               </ul>
           {% else %}
-              <ul class="govuk-list govuk-list__orange govuk-list--spaced">
+              <ul class="govuk-list govuk-list__orange">
                   {% for startEnd in room.hourlySlots[index].freeSlots %}
                       <li>Free {{ startEnd.startTime }} - {{ startEnd.endTime }}</li>
                   {% endfor %}


### PR DESCRIPTION
Weekend dates are not supported, they are disabled in the date picker but also need validation enforcement if the user enters the date in manually.

If a weekend date is supplied as a GET request parameter then it will default to the next following Monday.