### PR TITLE
BAVL-1415 small content change for the official visit video events filter.

### DIFF
--- a/integration_tests/specs/dailySchedule.spec.ts
+++ b/integration_tests/specs/dailySchedule.spec.ts
@@ -54,7 +54,7 @@ test.describe('Daily schedule', () => {
     await homePage.applyFiltersButton.click()
     await expect(page.getByText('Filter returned 0 results.')).toBeVisible()
     await homePage.showFiltersButton.click()
-    await homePage.selectCheckbox('Official Visit')
+    await homePage.selectCheckbox('Official Visit - Video')
     await homePage.applyFiltersButton.click()
     await expect(page.getByText('Filter returned 1 results.')).toBeVisible()
     await homePage.printAllMovementSlipsLink.click()

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -97,7 +97,7 @@ describe('Reference data service', () => {
         { code: 'VLLA', description: 'Video Link - Legal Appointment' },
         { code: 'VLOO', description: 'Video Link - Official Other' },
         { code: 'VLPA', description: 'Video Link - Parole Hearing' },
-        { code: 'VLOV', description: 'Official Visit' },
+        { code: 'VLOV', description: 'Official Visit - Video' },
       ])
       expect(activitiesAndAppointmentsApiClient.getAppointmentCategories).not.toHaveBeenCalledWith(user)
     })

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -27,7 +27,7 @@ const BVLS_TYPES = [
   { code: 'VLPM', description: 'Video Link - Probation Meeting' },
 ] as VideoEventType[]
 
-export const OFFICIAL_VISIT_TYPE = { code: 'VLOV', description: 'Official Visit' } as VideoEventType
+export const OFFICIAL_VISIT_TYPE = { code: 'VLOV', description: 'Official Visit - Video' } as VideoEventType
 
 export const VIDEO_EVENT_TYPES = [...BVLS_TYPES, ...APPOINTMENT_TYPES, OFFICIAL_VISIT_TYPE] as VideoEventType[]
 


### PR DESCRIPTION
`Official Visit` label on the filter changed to `Official Visit - Video`

<img width="4464" height="2104" alt="image" src="https://github.com/user-attachments/assets/08524b3d-a6da-4b0d-9ed9-bcc8e009e002" />
