### PR TITLE
BAVL-1359 refactoring CSS/HTML and moving navigation above tabs to be inline with figma design.

### DIFF
--- a/frontend/components/room-availability/room-availability.scss
+++ b/frontend/components/room-availability/room-availability.scss
@@ -4,6 +4,10 @@
   &--no-text-transform {
     text-transform: none;
   }
+
+  &--spacing {
+    margin-bottom: 10px;
+  }
 }
 
 .govuk-table {

--- a/server/views/pages/availabilityChecker/availabilityChecker.njk
+++ b/server/views/pages/availabilityChecker/availabilityChecker.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 
 {% set hideBackLink = true %}
@@ -259,19 +260,27 @@
 
 {% macro roomHtml(room, index) %}
     {% if not room.hourlySlots[index].freeSlots.length %}
-        <div class="govuk-table__cell--booked">Booked</div>
+        <div data-qa="{{ room.id }}-booked-{{ room.date }}-{{ room.hourlySlots[index].hour }}">Booked</div>
     {% else %}
         {% if room.hourlySlots[index].freeSlots.length %}
             {% if room.hourlySlots[index].freeSlots.length == 1 and room.hourlySlots[index].freeSlots[0].durationInMinutes == 60 %}
-                <ul class="govuk-list govuk-list__green">
-                    <li>Free</li>
-                </ul>
+                {{ govukTag({
+                    text: 'Available',
+                    classes: 'govuk-tag--no-text-transform govuk-tag--green',
+                    attributes: {
+                        'data-qa': room.id + '-available-' + room.date + '-' + room.hourlySlots[index].hour
+                    }
+                }) }}
             {% else %}
-                <ul class="govuk-list govuk-list__orange">
-                    {% for startEnd in room.hourlySlots[index].freeSlots %}
-                        <li>Free {{ startEnd.startTime }} - {{ startEnd.endTime }}</li>
-                    {% endfor %}
-                </ul>
+                {% for startEnd in room.hourlySlots[index].freeSlots %}
+                    {{ govukTag({
+                        html: '<div>Available</div><div>' + startEnd.startTime + ' - ' + startEnd.endTime + '</div>',
+                        classes: 'govuk-tag--no-text-transform govuk-tag--spacing govuk-tag--orange',
+                        attributes: {
+                            'data-qa': room.id + '-available-' + room.date + '-' + startEnd.startTime + '-' + startEnd.endTime
+                        }
+                    }) }}
+                {% endfor %}
             {% endif %}
         {% endif %}
     {% endif %}

--- a/server/views/pages/availabilityChecker/workingWeekAvailabilityChecker.njk
+++ b/server/views/pages/availabilityChecker/workingWeekAvailabilityChecker.njk
@@ -86,6 +86,17 @@
         <div class="govuk-grid-column-full">
             <div class="govuk-heading-s">Date and time availability</div>
             <p class="govuk-body-m">Last updated {{ now() | formatDate('HH:mm') }}</p>
+            {{ govukPagination({
+                previous: {
+                    text: 'Previous week',
+                    href: "/availability-checker?date=" + previousWeek | formatDate('yyyy-MM-dd') + "&period=" + period
+                },
+                next: {
+                    text: 'Next week',
+                    href: "/availability-checker?date=" + nextWeek | formatDate('yyyy-MM-dd') + "&period=" + period
+                },
+                items: []
+            }) }}
             <div>
                 {{ govukTabs({
                     items: [
@@ -127,17 +138,6 @@
                     ]
                 }) }}
             </div>
-            {{ govukPagination({
-                previous: {
-                    text: 'Previous week',
-                    href: "/availability-checker?date=" + previousWeek | formatDate('yyyy-MM-dd') + "&period=" + period
-                },
-                next: {
-                    text: 'Next week',
-                    href: "/availability-checker?date=" + nextWeek | formatDate('yyyy-MM-dd') + "&period=" + period
-                },
-                items: []
-            }) }}
         </div>
     </div>
 {% endblock %}

--- a/server/views/partials/availability.njk
+++ b/server/views/partials/availability.njk
@@ -207,13 +207,12 @@
             {% else %}
                 {% for startEnd in room.hourlySlots[index].freeSlots %}
                     {{ govukTag({
-                        html: '<div><div>Available</div><div>' + startEnd.startTime + ' - ' + startEnd.endTime + '</div></div>',
-                        classes: 'govuk-tag--no-text-transform govuk-tag--orange',
+                        html: '<div>Available</div><div>' + startEnd.startTime + ' - ' + startEnd.endTime + '</div>',
+                        classes: 'govuk-tag--no-text-transform govuk-tag--spacing govuk-tag--orange',
                         attributes: {
                             'data-qa': room.id + '-available-' + room.date + '-' + startEnd.startTime + '-' + startEnd.endTime
                         }
                     }) }}
-                    <p></p>
                 {% endfor %}
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Refactoring CSS/HTML and moving navigation to be above the tabbed view to bring inline with latest figma designs.

<img width="4388" height="2322" alt="image" src="https://github.com/user-attachments/assets/f37bf442-666f-4113-8302-6c076ba0dae1" />

<img width="4388" height="2322" alt="image" src="https://github.com/user-attachments/assets/602c0188-c5d8-4114-bdd0-860c4b467abe" />
