### PR TITLE
BAVL-1359 small styling tweaks and stopping anchor page jumping as not deemed user accessible.

### DIFF
--- a/frontend/components/room-availability/room-availability.scss
+++ b/frontend/components/room-availability/room-availability.scss
@@ -14,8 +14,12 @@
   .govuk-table__header {
     @extend .govuk-table__header;
 
-    &--no-header {
+    &--no-border-top {
       border-top: none;
+    }
+
+    &--no-border-bottom {
+      border-bottom: none;
     }
   }
 }

--- a/integration_tests/specs/availabilityChecker.spec.ts
+++ b/integration_tests/specs/availabilityChecker.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { previousFriday, previousMonday, previousThursday, previousTuesday, previousWednesday } from 'date-fns'
 import bookAVideoLinkApi from '../mockApis/bookAVideoLinkApi'
 import componentsApi from '../mockApis/componentsApi'
@@ -102,10 +102,17 @@ test.describe('Availability Checker', () => {
 
     await availabilityCheckerPage.selectDate(previousMonday(monday))
     await availabilityCheckerPage.selectSession(Session.AFTERNOON)
+
+    // Selecting Friday tab to ensure it stripped from the URL after posting/updating the page
+    await availabilityCheckerPage.selectWeekDayTab(friday)
+    await expect(page).toHaveURL('/availability-checker?date=2026-07-27&period=AM#friday')
+
     await availabilityCheckerPage.update()
 
     await availabilityCheckerPage.assertSessionSelected(Session.AFTERNOON)
     await availabilityCheckerPage.assertWeekDayTabSelected(WeekDay.MONDAY)
+
+    await expect(page).toHaveURL('/availability-checker?date=2026-07-20&period=PM#')
   })
 
   test('User can view previous week and next week on the availability checker', async ({ page }) => {

--- a/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.test.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.test.ts
@@ -369,19 +369,16 @@ describe('POST', () => {
   })
 
   it.each([
-    ['10/12/2024', 'AM', '2024-12-10', 'tuesday'],
-    ['11/12/2024', 'PM', '2024-12-11', 'wednesday'],
-    ['12/12/2024', 'ED', '2024-12-12', 'thursday'],
-  ])(
-    'should redirect to date and period (%s) (%s)',
-    (date: string, period: string, parsedDate: string, day: string) => {
-      return request(app)
-        .post('/availability-checker')
-        .send({ date, period })
-        .expect(302)
-        .expect('location', `availability-checker?date=${parsedDate}&period=${period}#${day}`)
-    },
-  )
+    ['10/12/2024', 'AM', '2024-12-10'],
+    ['11/12/2024', 'PM', '2024-12-11'],
+    ['12/12/2024', 'ED', '2024-12-12'],
+  ])('should redirect to date and period (%s) (%s)', (date: string, period: string, parsedDate: string) => {
+    return request(app)
+      .post('/availability-checker')
+      .send({ date, period })
+      .expect(302)
+      .expect('location', `availability-checker?date=${parsedDate}&period=${period}#`)
+  })
 
   it.each([['25/07/2026'], ['26/07/2026']])('should validate date is a working day', (date: string) => {
     return request(app)

--- a/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.ts
@@ -5,10 +5,7 @@ import { IsNotEmpty } from 'class-validator'
 import {
   formatDate,
   isMonday,
-  isThursday,
-  isTuesday,
   isValid,
-  isWednesday,
   isWeekend,
   nextFriday,
   nextMonday,
@@ -99,23 +96,10 @@ export default class WorkingWeekAvailabilityCheckerHandler implements PageHandle
       period,
     })
 
-    const weekDay = startOfDay(date)
+    // If a tab has been select prior to POST it is remembered; this makes sure it is overridden.
+    const overrideTabAnchorNavigation = '#'
 
-    let selectedDay
-
-    if (isMonday(weekDay)) {
-      selectedDay = '#monday'
-    } else if (isTuesday(weekDay)) {
-      selectedDay = '#tuesday'
-    } else if (isWednesday(weekDay)) {
-      selectedDay = '#wednesday'
-    } else if (isThursday(weekDay)) {
-      selectedDay = '#thursday'
-    } else {
-      selectedDay = '#friday'
-    }
-
-    return res.redirect(`availability-checker?${queryParams}${selectedDay}`)
+    return res.redirect(`availability-checker?${queryParams}${overrideTabAnchorNavigation}`)
   }
 
   private startAndEndOfWeek = (date: Date) => {

--- a/server/views/pages/availabilityChecker/workingWeekAvailabilityChecker.njk
+++ b/server/views/pages/availabilityChecker/workingWeekAvailabilityChecker.njk
@@ -104,36 +104,36 @@
                             label: monday | formatDate('iii d MMM'),
                             id: "monday",
                             panel: {
-                            html: availability(period, mondayAvailability)
-                        }
+                                html: availability(period, mondayAvailability)
+                            }
                         },
                         {
                             label: tuesday | formatDate('iii d MMM'),
                             id: "tuesday",
                             panel: {
-                            html: availability(period, tuesdayAvailability)
-                        }
+                                html: availability(period, tuesdayAvailability)
+                            }
                         },
                         {
                             label: wednesday | formatDate('iii d MMM'),
                             id: "wednesday",
                             panel: {
-                            html: availability(period, wednesdayAvailability)
-                        }
+                                html: availability(period, wednesdayAvailability)
+                            }
                         },
                         {
                             label: thursday | formatDate('iii d MMM'),
                             id: "thursday",
                             panel: {
-                            html: availability(period, thursdayAvailability)
-                        }
+                                html: availability(period, thursdayAvailability)
+                            }
                         },
                         {
                             label: friday | formatDate('iii d MMM'),
                             id: "friday",
                             panel: {
-                            html: availability(period, fridayAvailability)
-                        }
+                                html: availability(period, fridayAvailability)
+                            }
                         }
                     ]
                 }) }}

--- a/server/views/partials/availability.njk
+++ b/server/views/partials/availability.njk
@@ -11,30 +11,30 @@
                 head: [
                     {
                         text: "Rooms",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "08:00",
                         attributes: {
                           "data-qa": "time-8"
                         },
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "09:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "10:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "11:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "12:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     }
                 ],
                 rows: rows
@@ -46,30 +46,30 @@
                 head: [
                     {
                         text: "Rooms",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "13:00",
                         attributes: {
                           "data-qa": "time-13"
                         },
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "14:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "15:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "16:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "17:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     }
                 ],
                 rows: rows
@@ -81,22 +81,22 @@
                 head: [
                     {
                         text: "Rooms",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "18:00",
                         attributes: {
                           "data-qa": "time-18"
                         },
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "19:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     },
                     {
                         text: "20:00",
-                        classes: 'govuk-table__header--no-header'
+                        classes: 'govuk-table__header--no-border-top'
                     }
                 ],
                 rows: rows
@@ -107,11 +107,13 @@
 
 {% macro roomsAvailabilityRows(period, roomAvailability, rows) %}
     {% for room in roomAvailability %}
+        {% set classes = 'govuk-table__header--no-border-bottom' if loop.last else '' %}
         {% if period == "ED" %}
             {% set rows = (rows.push(
                 [
                     {
                         text: room.description,
+                        classes: classes,
                         attributes: {
                           'width': '40%',
                           'word-break': 'break-all'
@@ -119,6 +121,7 @@
                     },
                     {
                         html: roomHtml(room, 0),
+                        classes: classes,
                         attributes: {
                           'width': '20%',
                           'word-break': 'break-all'
@@ -126,6 +129,7 @@
                     },
                     {
                         html: roomHtml(room, 1),
+                        classes: classes,
                         attributes: {
                           'width': '20%',
                           'word-break': 'break-all'
@@ -133,6 +137,7 @@
                     },
                     {
                         html: roomHtml(room, 2),
+                        classes: classes,
                         attributes: {
                           'width': '20%',
                           'word-break': 'break-all'
@@ -145,6 +150,7 @@
                 [
                     {
                         text: room.description,
+                        classes: classes,
                         attributes: {
                           'width': '20%',
                           'word-break': 'break-all'
@@ -152,6 +158,7 @@
                     },
                     {
                         html: roomHtml(room, 0),
+                        classes: classes,
                         attributes: {
                           'width': '16%',
                           'word-break': 'break-all'
@@ -159,6 +166,7 @@
                     },
                     {
                         html: roomHtml(room, 1),
+                        classes: classes,
                         attributes: {
                           'width': '16%',
                           'word-break': 'break-all'
@@ -166,6 +174,7 @@
                     },
                     {
                         html: roomHtml(room, 2),
+                        classes: classes,
                         attributes: {
                           'width': '16%',
                           'word-break': 'break-all'
@@ -173,6 +182,7 @@
                     },
                     {
                         html: roomHtml(room, 3),
+                        classes: classes,
                         attributes: {
                           'width': '16%',
                           'word-break': 'break-all'
@@ -180,6 +190,7 @@
                     },
                     {
                         html: roomHtml(room, 4),
+                        classes: classes,
                         attributes: {
                           'width': '16%',
                           'word-break': 'break-all'


### PR DESCRIPTION
Removed bottom border from tables with tabs and stopping anchor page jumping on the back of accessibility concerns.

Before: 
<img width="4394" height="2232" alt="Screenshot 2026-08-05 at 17-29-22 Video link availability checker Risley (HMP) Video Conference Schedule MoJ" src="https://github.com/user-attachments/assets/98abe086-9bb6-44cd-a3a1-8ff94372ffa3" />

After:
<img width="4394" height="2232" alt="Screenshot 2026-08-05 at 17-22-35 Video link availability checker Risley (HMP) Video Conference Schedule MoJ" src="https://github.com/user-attachments/assets/6d6d4387-6bc5-4026-b989-b6630b3322ec" />

