### PR TITLE
BAVL-1352 moving away from using the term 'availability checker' and replacing with 'room availability' as this in more in line with the users needs.

### DIFF
--- a/integration_tests/pages/availabilityCheckerPage.ts
+++ b/integration_tests/pages/availabilityCheckerPage.ts
@@ -38,7 +38,7 @@ export default class AvailabilityCheckerPage extends AbstractPage {
 
   private constructor(page: Page) {
     super(page)
-    this.header = page.locator('h1', { hasText: 'Video room availability checker:  Moorland (HMP)' })
+    this.header = page.locator('h1', { hasText: 'Video room availability:  Moorland (HMP)' })
     this.date = page.getByLabel('Date')
     this.morningSession = page.locator('#period')
     this.afternoonSession = page.locator('#period-2')

--- a/integration_tests/specs/availabilityChecker.spec.ts
+++ b/integration_tests/specs/availabilityChecker.spec.ts
@@ -48,8 +48,8 @@ test.describe('Availability Checker', () => {
     await resetStubs()
   })
 
-  test('User can view the availability checker', async ({ page }) => {
-    await login(page, { name: 'A TestUser' }, `/availability-checker?date=${formatDate(monday, 'yyyy-MM-dd')}`)
+  test('User can view the room availability', async ({ page }) => {
+    await login(page, { name: 'A TestUser' }, `/room-availability?date=${formatDate(monday, 'yyyy-MM-dd')}`)
 
     const availabilityCheckerPage = await AvailabilityCheckerPage.verifyOnPage(page)
     await availabilityCheckerPage.assertSessionSelected(Session.MORNING)
@@ -61,12 +61,8 @@ test.describe('Availability Checker', () => {
     await availabilityCheckerPage.assertRoomPartiallyAvailable('vvc-room-1', monday, '12:45', '13:00')
   })
 
-  test('User can view each tab on the availability checker', async ({ page }) => {
-    await login(
-      page,
-      { name: 'A TestUser' },
-      `/availability-checker?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM`,
-    )
+  test('User can view each tab on the room availability', async ({ page }) => {
+    await login(page, { name: 'A TestUser' }, `/room-availability?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM`)
 
     const availabilityCheckerPage = await AvailabilityCheckerPage.verifyOnPage(page)
     await availabilityCheckerPage.assertSessionSelected(Session.MORNING)
@@ -105,12 +101,8 @@ test.describe('Availability Checker', () => {
     await availabilityCheckerPage.assertRoomBooked('vvc-room-1', friday, 12)
   })
 
-  test('User can change the date and session on the availability checker', async ({ page }) => {
-    await login(
-      page,
-      { name: 'A TestUser' },
-      `/availability-checker?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM`,
-    )
+  test('User can change the date and session on the room availability', async ({ page }) => {
+    await login(page, { name: 'A TestUser' }, `/room-availability?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM`)
 
     const availabilityCheckerPage = await AvailabilityCheckerPage.verifyOnPage(page)
     await availabilityCheckerPage.assertSessionSelected(Session.MORNING)
@@ -128,24 +120,18 @@ test.describe('Availability Checker', () => {
 
     // Selecting Friday tab to ensure it stripped from the URL after posting/updating the page
     await availabilityCheckerPage.selectWeekDayTab(friday)
-    await expect(page).toHaveURL(`/availability-checker?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM#friday`)
+    await expect(page).toHaveURL(`/room-availability?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM#friday`)
 
     await availabilityCheckerPage.update()
 
     await availabilityCheckerPage.assertSessionSelected(Session.AFTERNOON)
     await availabilityCheckerPage.assertWeekDayTabSelected(WeekDay.MONDAY)
 
-    await expect(page).toHaveURL(
-      `/availability-checker?date=${formatDate(subWeeks(monday, 1), 'yyyy-MM-dd')}&period=PM#`,
-    )
+    await expect(page).toHaveURL(`/room-availability?date=${formatDate(subWeeks(monday, 1), 'yyyy-MM-dd')}&period=PM#`)
   })
 
-  test('User can view previous, current and next week on the availability checker', async ({ page }) => {
-    await login(
-      page,
-      { name: 'A TestUser' },
-      `/availability-checker?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM`,
-    )
+  test('User can view previous, current and next week on the room availability', async ({ page }) => {
+    await login(page, { name: 'A TestUser' }, `/room-availability?date=${formatDate(monday, 'yyyy-MM-dd')}&period=AM`)
 
     const availabilityCheckerPage = await AvailabilityCheckerPage.verifyOnPage(page)
     await availabilityCheckerPage.assertSessionSelected(Session.MORNING)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,7 +7,7 @@ export default function routes(services: Services): Router {
   const router = Router()
 
   router.use('/', dailySchedule(services))
-  router.use('/availability-checker', availabilityChecker(services))
+  router.use('/room-availability', availabilityChecker(services))
 
   return router
 }

--- a/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.test.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.test.ts
@@ -58,7 +58,7 @@ describe('GET', () => {
       config.featureToggles.availabilityCheckerPrisons = 'RSI'
 
       return request(app)
-        .get(`/availability-checker?period=${period}&date=${date}`)
+        .get(`/room-availability?period=${period}&date=${date}`)
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = load(res.text)
@@ -91,7 +91,7 @@ describe('GET', () => {
     config.featureToggles.availabilityCheckerPrisons = 'RSI'
 
     return request(app)
-      .get(`/availability-checker?period=AM&date=${weekendDate}`)
+      .get(`/room-availability?period=AM&date=${weekendDate}`)
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
@@ -116,7 +116,7 @@ describe('GET', () => {
     config.featureToggles.availabilityCheckerPrisons = 'MDI'
 
     return request(app)
-      .get('/availability-checker')
+      .get('/room-availability')
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
@@ -133,7 +133,7 @@ describe('GET', () => {
 
   it('should not render availability checker when no prison is enabled', () => {
     return request(app)
-      .get('/availability-checker')
+      .get('/room-availability')
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
@@ -162,17 +162,17 @@ describe('POST', () => {
     config.featureToggles.availabilityCheckerPrisons = 'RSI'
 
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date, period })
       .expect(302)
-      .expect('location', `availability-checker?date=${parsedDate}&period=${period}`)
+      .expect('location', `room-availability?date=${parsedDate}&period=${period}`)
   })
 
   it.each([['25/07/2026'], ['26/07/2026']])('should validate date is a working day', (date: string) => {
     config.featureToggles.availabilityCheckerPrisons = 'RSI'
 
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date, period: 'AM' })
       .expect(() => {
         expectErrorMessages([
@@ -189,7 +189,7 @@ describe('POST', () => {
     config.featureToggles.availabilityCheckerPrisons = 'RSI'
 
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ period: 'AM' })
       .expect(() => {
         expectErrorMessages([
@@ -206,7 +206,7 @@ describe('POST', () => {
     config.featureToggles.availabilityCheckerPrisons = 'RSI'
 
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date: '31/02/2026', period: 'AM' })
       .expect(() => {
         expectErrorMessages([
@@ -223,7 +223,7 @@ describe('POST', () => {
     config.featureToggles.availabilityCheckerPrisons = 'RSI'
 
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date: '03/02/2026' })
       .expect(() => {
         expectErrorMessages([

--- a/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/availabilityCheckerHandler.ts
@@ -69,6 +69,6 @@ export default class AvailabilityCheckerHandler implements PageHandler {
       period,
     })
 
-    return res.redirect(`availability-checker?${queryParams}`)
+    return res.redirect(`room-availability?${queryParams}`)
   }
 }

--- a/server/routes/journeys/availabilityChecker/handlers/timelineAvailabilityCheckerHandler.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/timelineAvailabilityCheckerHandler.ts
@@ -70,6 +70,6 @@ export default class TimelineAvailabilityCheckerHandler implements PageHandler {
       period,
     })
 
-    return res.redirect(`availability-checker?${queryParams}`)
+    return res.redirect(`room-availability?${queryParams}`)
   }
 }

--- a/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.test.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.test.ts
@@ -34,6 +34,8 @@ const risleyPrison: Prison = {
   enabled: true,
 }
 
+const pageHeader = 'Video room availability: Risley (HMP)'
+
 const appSetup = (journeySession = {}) => {
   app = appWithAllRoutes({
     services: { auditService, roomAvailabilityService, telemetryService },
@@ -303,12 +305,12 @@ describe('GET', () => {
     roomAvailabilityService.getRoomAvailability.mockResolvedValue(morningRoomAvailability)
 
     return request(app)
-      .get(`/availability-checker?period=AM&date=2026-07-28`)
+      .get(`/room-availability?period=AM&date=2026-07-28`)
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
 
-        expect(getPageHeader($)).toEqual('Video room availability checker: Risley (HMP)')
+        expect(getPageHeader($)).toEqual(pageHeader)
         expect(getByDataQa($, 'appointments-link').attr('href')).toEqual(
           'http://localhost:3000/appointments/create/start-group',
         )
@@ -361,7 +363,7 @@ describe('GET', () => {
           correlationId: expect.any(String),
           details: JSON.stringify({ query: { period: 'AM', date: '2026-07-28' } }),
         })
-        expect(telemetryService.trackEvent).toHaveBeenCalledWith('DailySchedule_ViewAvailabilityCheck', {
+        expect(telemetryService.trackEvent).toHaveBeenCalledWith('DailySchedule_ViewRoomAvailability', {
           date: '2026-07-28',
           period: 'AM',
           prisonCode: 'RSI',
@@ -378,17 +380,17 @@ describe('GET', () => {
     roomAvailabilityService.getRoomAvailability.mockResolvedValue([])
 
     return request(app)
-      .get(`/availability-checker?period=PM&date=${formatDate(previousWeek, 'yyyy-MM-dd')}`)
+      .get(`/room-availability?period=PM&date=${formatDate(previousWeek, 'yyyy-MM-dd')}`)
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
 
-        expect(getPageHeader($)).toEqual('Video room availability checker: Risley (HMP)')
+        expect(getPageHeader($)).toEqual(pageHeader)
         expect(existsByDataQa($, 'current-week')).toBe(true)
         expect(getByDataQa($, 'current-week').attr('href')).toEqual(
-          `/availability-checker?date=${formatDate(mondayOfCurrentWeek, 'yyyy-MM-dd')}&period=PM`,
+          `/room-availability?date=${formatDate(mondayOfCurrentWeek, 'yyyy-MM-dd')}&period=PM`,
         )
-        expect(telemetryService.trackEvent).toHaveBeenCalledWith('DailySchedule_ViewAvailabilityCheck', {
+        expect(telemetryService.trackEvent).toHaveBeenCalledWith('DailySchedule_ViewRoomAvailability', {
           date: formatDate(previousWeek, 'yyyy-MM-dd'),
           period: 'PM',
           prisonCode: 'RSI',
@@ -403,15 +405,15 @@ describe('GET', () => {
     roomAvailabilityService.getRoomAvailability.mockResolvedValue([])
 
     return request(app)
-      .get(`/availability-checker?period=AM&date=${formatDate(nextWeek, 'yyyy-MM-dd')}`)
+      .get(`/room-availability?period=AM&date=${formatDate(nextWeek, 'yyyy-MM-dd')}`)
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
 
-        expect(getPageHeader($)).toEqual('Video room availability checker: Risley (HMP)')
+        expect(getPageHeader($)).toEqual(pageHeader)
         expect(existsByDataQa($, 'current-week')).toBe(true)
         expect(getByDataQa($, 'current-week').attr('href')).toEqual(
-          `/availability-checker?date=${formatDate(mondayOfCurrentWeek, 'yyyy-MM-dd')}&period=AM`,
+          `/room-availability?date=${formatDate(mondayOfCurrentWeek, 'yyyy-MM-dd')}&period=AM`,
         )
       })
   })
@@ -422,12 +424,12 @@ describe('GET', () => {
     roomAvailabilityService.getRoomAvailability.mockResolvedValue([])
 
     return request(app)
-      .get(`/availability-checker?period=AM&date=${formatDate(today, 'yyyy-MM-dd')}`)
+      .get(`/room-availability?period=AM&date=${formatDate(today, 'yyyy-MM-dd')}`)
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
 
-        expect(getPageHeader($)).toEqual('Video room availability checker: Risley (HMP)')
+        expect(getPageHeader($)).toEqual(pageHeader)
         expect(existsByDataQa($, 'current-week')).toBe(false)
       })
   })
@@ -436,12 +438,12 @@ describe('GET', () => {
     roomAvailabilityService.getRoomAvailability.mockResolvedValue([])
 
     return request(app)
-      .get(`/availability-checker?period=AM&date=2025-12-31`)
+      .get(`/room-availability?period=AM&date=2025-12-31`)
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = load(res.text)
 
-        expect(getPageHeader($)).toEqual('Video room availability checker: Risley (HMP)')
+        expect(getPageHeader($)).toEqual(pageHeader)
 
         // boundary date tab labels are inclusive of year
         expect(getByDataQa($, 'wednesday_tab').text().trim()).toEqual('Wed 31 Dec 2025')
@@ -468,15 +470,15 @@ describe('POST', () => {
     ['12/12/2024', 'ED', '2024-12-12'],
   ])('should redirect to date and period (%s) (%s)', (date: string, period: string, parsedDate: string) => {
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date, period })
       .expect(302)
-      .expect('location', `availability-checker?date=${parsedDate}&period=${period}#`)
+      .expect('location', `room-availability?date=${parsedDate}&period=${period}#`)
   })
 
   it.each([['25/07/2026'], ['26/07/2026']])('should validate date is a working day', (date: string) => {
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date, period: 'AM' })
       .expect(() => {
         expectErrorMessages([
@@ -491,7 +493,7 @@ describe('POST', () => {
 
   it('should validate date provided', () => {
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ period: 'AM' })
       .expect(() => {
         expectErrorMessages([
@@ -506,7 +508,7 @@ describe('POST', () => {
 
   it('should validate date is valid', () => {
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date: '31/02/2026', period: 'AM' })
       .expect(() => {
         expectErrorMessages([
@@ -521,7 +523,7 @@ describe('POST', () => {
 
   it('should validate session is provided', () => {
     return request(app)
-      .post('/availability-checker')
+      .post('/room-availability')
       .send({ date: '03/02/2026' })
       .expect(() => {
         expectErrorMessages([

--- a/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.ts
+++ b/server/routes/journeys/availabilityChecker/handlers/workingWeekAvailabilityCheckerHandler.ts
@@ -60,21 +60,21 @@ export default class WorkingWeekAvailabilityCheckerHandler implements PageHandle
       const date = startOfDay(isValid(dateFromQueryParam) ? dateFromQueryParam : new Date())
       const weekDay = isWeekend(date) ? nextMonday(date) : date
       const period: Period = <Period>req.query.period || 'AM'
-      const { startDate, endDate } = this.startAndEndOfWeek(weekDay)
+      const { monday, friday } = this.startAndEndOfWeek(weekDay)
       const roomAvailability = await this.roomAvailabilityService.getRoomAvailability(
         prison.code,
-        startDate,
-        endDate,
+        monday,
+        friday,
         period,
         user,
       )
 
       const dayFilter = (availability: RoomAvailability, day: Date) =>
         availability.date === formatDate(day, 'yyyy-MM-dd')
-      const currentWeek = this.startAndEndOfWeek(new Date())
+      const currentWorkingWeek = this.startAndEndOfWeek(new Date())
       const isCurrentWeek = isWithinInterval(weekDay, {
-        start: startOfDay(currentWeek.startDate),
-        end: endOfDay(currentWeek.endDate),
+        start: startOfDay(currentWorkingWeek.monday),
+        end: endOfDay(currentWorkingWeek.friday),
       })
 
       const eventToRecord = {
@@ -84,26 +84,26 @@ export default class WorkingWeekAvailabilityCheckerHandler implements PageHandle
         username: user?.username,
       }
 
-      this.telemetryService.trackEvent('DailySchedule_ViewAvailabilityCheck', eventToRecord)
+      this.telemetryService.trackEvent('DailySchedule_ViewRoomAvailability', eventToRecord)
 
       res.render('pages/availabilityChecker/workingWeekAvailabilityChecker', {
         prison,
         date: weekDay,
         period,
         appointmentsLink: `${config.activitiesAndAppointmentsUrl}/appointments/create/start-group`,
-        monday: startDate,
-        tuesday: nextTuesday(startDate),
-        wednesday: nextWednesday(startDate),
-        thursday: nextThursday(startDate),
-        friday: endDate,
-        mondayAvailability: roomAvailability.filter(ra => dayFilter(ra, startDate)),
-        tuesdayAvailability: roomAvailability.filter(ra => dayFilter(ra, nextTuesday(startDate))),
-        wednesdayAvailability: roomAvailability.filter(ra => dayFilter(ra, nextWednesday(startDate))),
-        thursdayAvailability: roomAvailability.filter(ra => dayFilter(ra, nextThursday(startDate))),
-        fridayAvailability: roomAvailability.filter(ra => dayFilter(ra, endDate)),
-        previousWeek: previousMonday(startDate),
-        nextWeek: nextMonday(endDate),
-        currentWeekStartDate: isCurrentWeek ? undefined : startOfDay(currentWeek.startDate),
+        monday,
+        tuesday: nextTuesday(monday),
+        wednesday: nextWednesday(monday),
+        thursday: nextThursday(monday),
+        friday,
+        mondayAvailability: roomAvailability.filter(ra => dayFilter(ra, monday)),
+        tuesdayAvailability: roomAvailability.filter(ra => dayFilter(ra, nextTuesday(monday))),
+        wednesdayAvailability: roomAvailability.filter(ra => dayFilter(ra, nextWednesday(monday))),
+        thursdayAvailability: roomAvailability.filter(ra => dayFilter(ra, nextThursday(monday))),
+        fridayAvailability: roomAvailability.filter(ra => dayFilter(ra, friday)),
+        previousWeek: previousMonday(monday),
+        nextWeek: nextMonday(friday),
+        currentWeekStartDate: isCurrentWeek ? undefined : startOfDay(currentWorkingWeek.monday),
       })
     } else {
       res.render('pages/error/404')
@@ -120,20 +120,20 @@ export default class WorkingWeekAvailabilityCheckerHandler implements PageHandle
     // If a tab has been select prior to POST it is remembered; this makes sure it is overridden.
     const overrideTabAnchorNavigation = '#'
 
-    return res.redirect(`availability-checker?${queryParams}${overrideTabAnchorNavigation}`)
+    return res.redirect(`room-availability?${queryParams}${overrideTabAnchorNavigation}`)
   }
 
   private startAndEndOfWeek = (date: Date) => {
     if (isMonday(date)) {
       return {
-        startDate: date,
-        endDate: nextFriday(date),
+        monday: date,
+        friday: nextFriday(date),
       }
     }
 
     return {
-      startDate: previousMonday(date),
-      endDate: nextFriday(previousMonday(date)),
+      monday: previousMonday(date),
+      friday: nextFriday(previousMonday(date)),
     }
   }
 }

--- a/server/views/pages/availabilityChecker/workingWeekAvailabilityChecker.njk
+++ b/server/views/pages/availabilityChecker/workingWeekAvailabilityChecker.njk
@@ -8,7 +8,7 @@
 {% from "partials/availability.njk" import availability %}
 
 {% set hideBackLink = true %}
-{% set pageTitle = "Video room availability checker: " + prison.name %}
+{% set pageTitle = "Video room availability: " + prison.name %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -89,16 +89,16 @@
             {{ govukPagination({
                 previous: {
                     text: 'Previous week',
-                    href: "/availability-checker?date=" + previousWeek | formatDate('yyyy-MM-dd') + "&period=" + period
+                    href: "/room-availability?date=" + previousWeek | formatDate('yyyy-MM-dd') + "&period=" + period
                 },
                 next: {
                     text: 'Next week',
-                    href: "/availability-checker?date=" + nextWeek | formatDate('yyyy-MM-dd') + "&period=" + period
+                    href: "/room-availability?date=" + nextWeek | formatDate('yyyy-MM-dd') + "&period=" + period
                 },
                 items: [
                     {
                         number: 'Current week',
-                        href: "/availability-checker?date=" + currentWeekStartDate | formatDate('yyyy-MM-dd') + "&period=" + period,
+                        href: "/room-availability?date=" + currentWeekStartDate | formatDate('yyyy-MM-dd') + "&period=" + period,
                         attributes: {
                           "data-qa": "current-week"
                         }


### PR DESCRIPTION
This part 1 of 2 refactoring PR's.  I have kept this change minimal to keep the PR small.

The main impact is what the users sees and URL renaming.  We will be moving away from availability checker and more towards room availability in terms of terminology.

In the follow up PR I will look at renaming folders and files and the like.