### PR TITLE
BAVL-1447 adding temporary feedback banner using experimental GDS feature 'New Feature Banner'.

### DIFF
--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -8,3 +8,4 @@
 @import "./show-hide-link-button";
 @import "./room-availability";
 @import "./timeline-availability";
+@import "./new-features-banner";

--- a/assets/scss/components/_new-features-banner.scss
+++ b/assets/scss/components/_new-features-banner.scss
@@ -1,0 +1,16 @@
+.technical-updates-banner {
+  padding: 10px 0 0 0;
+  background: #44247b;
+}
+
+.technical-updates-container {
+  color: white;
+}
+
+.technical-updates-content {
+  text-align: left;
+}
+
+.technical-updates-whats-new {
+  margin-right: 10px;
+}

--- a/feature.env
+++ b/feature.env
@@ -16,6 +16,7 @@ DPS_URL=http://localhost:9091/dpshomepage
 OFFICIAL_VISITS_API_URL=http://localhost:9091/official-visits-api
 OFFICIAL_VISITS_URL=http://localhost:9091/official-visits-ui
 FEATURE_INCLUDE_OFFICIAL_VISITS=true
+ROOM_AVAILABILITY_FEEDBACK_URL=https://www.google.com
 
 TOKEN_VERIFICATION_ENABLED=true
 REDIS_ENABLED=false

--- a/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
+++ b/helm_deploy/hmpps-video-conference-schedule-ui/values.yaml
@@ -51,6 +51,7 @@ generic-service:
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
       FEEDBACK_URL: "FEEDBACK_URL?"
+      ROOM_AVAILABILITY_FEEDBACK_URL: "ROOM_AVAILABILITY_FEEDBACK_URL?"
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"

--- a/integration_tests/pages/homePage.ts
+++ b/integration_tests/pages/homePage.ts
@@ -48,4 +48,14 @@ export default class HomePage extends AbstractPage {
     await homePage.verifyNoAccessViolationsOnPage()
     return homePage
   }
+
+  async assertRoomAvailabilityFeedbackBannerIsVisible() {
+    await expect(this.page.locator('.technical-updates-banner')).toBeVisible()
+  }
+
+  async assertRoomAvailabilityFeedbackUrl(expected: string) {
+    const actual = await this.page.locator(`a[data-qa='room-availability-feedback-url']`).getAttribute('href')
+
+    expect(actual).toEqual(expected)
+  }
 }

--- a/integration_tests/specs/dailySchedule.spec.ts
+++ b/integration_tests/specs/dailySchedule.spec.ts
@@ -42,6 +42,8 @@ test.describe('Daily schedule', () => {
     await expect(homePage.prisonerStats).toHaveText('4')
     await expect(homePage.cancelledAppointmentStats).toHaveText('3')
     await expect(homePage.missingVideoLinkStats).toHaveText('1')
+    await homePage.assertRoomAvailabilityFeedbackBannerIsVisible()
+    await homePage.assertRoomAvailabilityFeedbackUrl('https://www.google.com')
     await homePage.showFiltersButton.click()
     await homePage.selectCheckbox('Video Link - Court Hearing')
     await homePage.selectCheckbox('Morning (AM)')
@@ -63,6 +65,7 @@ test.describe('Daily schedule', () => {
   test('User can view daily schedule cancelled appointments', async ({ page }) => {
     await login(page, { name: 'A TestUser' })
     const homePage = await HomePage.verifyOnPage(page)
+    await homePage.assertRoomAvailabilityFeedbackBannerIsVisible()
     await homePage.viewCancellationsLink.first().click()
     const cancellationsPage = await CancellationsPage.verifyOnPage(page)
     await expect(cancellationsPage.cancelledAppointmentStats).toHaveText('3')

--- a/server/config.ts
+++ b/server/config.ts
@@ -192,6 +192,7 @@ export default {
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
   feedbackUrl: get('FEEDBACK_URL', '#'),
+  roomAvailabilityFeedbackUrl: get('ROOM_AVAILABILITY_FEEDBACK_URL', '#'),
   applicationInsightsConnectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', '', requiredInProduction),
   featureToggles: {
     temporaryBlockingLocations: get('FEATURE_TEMPORARY_BLOCKING_LOCATIONS', false) === 'true',

--- a/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.test.ts
@@ -59,6 +59,7 @@ describe('GET', () => {
         const $ = cheerio.load(res.text)
         const heading = $('h1').text().trim()
 
+        expect(existsByDataQa($, 'room-availability-feedback-url')).toBe(true)
         expect(heading).toContain('Video link daily schedule: Moorland (HMP)')
         expect(existsByDataQa($, 'warning-text')).toBe(false)
         expect(existsByDataQa($, 'print-all-movement-slips')).toBe(true)
@@ -139,6 +140,7 @@ describe('GET', () => {
             isFutureDay: true,
             isPastDay: false,
             _locals: expect.any(Object),
+            roomAvailabilityFeedbackBanner: true,
           },
           expect.anything(),
         )
@@ -169,6 +171,7 @@ describe('GET', () => {
             isFutureDay: false,
             isPastDay: true,
             _locals: expect.any(Object),
+            roomAvailabilityFeedbackBanner: true,
           },
           expect.anything(),
         )
@@ -204,6 +207,7 @@ describe('GET', () => {
         const $ = cheerio.load(res.text)
         const heading = $('h1').text().trim()
 
+        expect(existsByDataQa($, 'room-availability-feedback-url')).toBe(true)
         expect(heading).toContain('Cancelled video appointments: Moorland (HMP)')
         expect(existsByClass($, 'govuk-warning-text')).toBe(false)
         expect(auditService.logPageView).toHaveBeenCalledWith(Page.DAILY_SCHEDULE_PAGE, {

--- a/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.ts
+++ b/server/routes/journeys/dailySchedule/handlers/dailyScheduleHandler.ts
@@ -93,12 +93,14 @@ export default class DailyScheduleHandler implements PageHandler {
           courtsAndProbationTeams,
           wings,
           appointmentsRolledOut,
+          roomAvailabilityFeedbackBanner: true,
         })
       : res.render('pages/dailySchedule/cancelledAppointments', {
           prison,
           appointmentsRolledOut,
           schedule,
           date,
+          roomAvailabilityFeedbackBanner: true,
         })
   }
 

--- a/server/routes/journeys/dailySchedule/handlers/selectDateHandler.test.ts
+++ b/server/routes/journeys/dailySchedule/handlers/selectDateHandler.test.ts
@@ -5,6 +5,7 @@ import { appWithAllRoutes, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import { expectErrorMessages } from '../../../testutils/expectErrorMessage'
 import expectJourneySession from '../../../testutils/testUtilRoute'
+import { existsByDataQa } from '../../../testutils/cheerio'
 
 jest.mock('../../../../services/auditService')
 
@@ -37,6 +38,7 @@ describe('GET', () => {
         const $ = cheerio.load(res.text)
         const heading = $('h1').text().trim()
 
+        expect(existsByDataQa($, 'room-availability-feedback-url')).toBe(true)
         expect(heading).toContain('Select the date you want to view a daily schedule for')
         expect(auditService.logPageView).toHaveBeenCalledWith(Page.SELECT_DATE_PAGE, {
           who: user.username,

--- a/server/routes/journeys/dailySchedule/handlers/selectDateHandler.ts
+++ b/server/routes/journeys/dailySchedule/handlers/selectDateHandler.ts
@@ -21,7 +21,8 @@ export default class SelectDateHandler implements PageHandler {
 
   public BODY = Body
 
-  GET = async (req: Request, res: Response) => res.render('pages/dailySchedule/selectDate', { date: req.query.date })
+  GET = async (req: Request, res: Response) =>
+    res.render('pages/dailySchedule/selectDate', { date: req.query.date, roomAvailabilityFeedbackBanner: true })
 
   POST = async (req: Request, res: Response) => {
     const { date } = req.body

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -32,6 +32,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
   app.locals.feedbackUrl = config.feedbackUrl
+  app.locals.roomAvailabilityFeedbackUrl = config.roomAvailabilityFeedbackUrl
   app.locals.applicationInsightsConnectionString = config.applicationInsightsConnectionString
   app.locals.applicationInsightsApplicationName = applicationInfo.applicationName
   app.locals.buildNumber = config.buildNumber

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,4 +1,5 @@
 {% extends "govuk/template.njk" %}
+{% from "./newFeaturesBanner.njk" import newFeaturesBanner %}
 
 {% set mainClasses = 'govuk-main-wrapper--l' %}
 
@@ -14,6 +15,13 @@
 {% block header %}
   {{ feComponents.header | safe }}
   {% block meta %}{% endblock %}
+
+  {% if roomAvailabilityFeedbackBanner %}
+    {{ newFeaturesBanner({
+      heading: 'Help us improve video appointment scheduling.',
+      html: 'Share your experience today by <a data-qa="room-availability-feedback-url" href="' + roomAvailabilityFeedbackUrl + '" class="govuk-link govuk-link--inverse" rel="noopener noreferrer" target="_blank">completing this short form</a>.'
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block beforeContent %}

--- a/server/views/partials/newFeaturesBanner.njk
+++ b/server/views/partials/newFeaturesBanner.njk
@@ -1,0 +1,11 @@
+{% macro newFeaturesBanner(params) %}
+    <div class="govuk-grid-row technical-updates-banner" id="technical-updates-banner">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-width-container govuk-body technical-updates-container">
+                <div class="technical-updates-content">
+                    <strong class="technical-updates-whats-new">{{ params.heading }}</strong> <span>{{ params.html | safe }}</span>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endmacro %}


### PR DESCRIPTION
This change uses the experimental new feature banner located [here](https://design-patterns.service.justice.gov.uk/components/new-features-banner/). There is no actual component only HTML and styling to be copied from.

Note there is no hide link.  The banner is short lived and was deemed not worth the effort.

The idea of the new banner is attempt to capture how users currently find if a room is available prior to the release of a new room availability feature due to be released in the next few weeks.

<img width="4258" height="2130" alt="feedback-banner-1" src="https://github.com/user-attachments/assets/fdff72c7-08e2-49a4-9f9d-3f5ac07619f9" />

<img width="4258" height="2130" alt="feedback-banner-2" src="https://github.com/user-attachments/assets/6874d780-7375-49e6-b0c7-8dcca3a6d24c" />

<img width="4258" height="2130" alt="feedback-banner-3" src="https://github.com/user-attachments/assets/818828bb-9d48-453a-87ab-697c85cd5e7e" />
